### PR TITLE
Windows support: run the demos and tests on win32-x64

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,9 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: npm run bun:test
 
-  # @gpuix/native 0.6.0's linux-x64-gnu prebuild carries no TestGpuixRenderer —
-  # it ships without the test-support feature — so the suites cannot run here.
-  # This checks the binding still loads, which is what the demos need.
+  # gpuix compiles TestGpuixRenderer only on macOS and Windows — it needs
+  # render_to_image, which the Vulkan/wgpu backend lacks — so the suites cannot
+  # run here. This checks the binding still loads, which is what the demos need.
   linux:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest]
+        os: [macos-14, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest]
+        os: [macos-14, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,11 @@ on:
 
 jobs:
   node:
-    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -17,7 +21,11 @@ jobs:
       - run: npm test
 
   bun:
-    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       # Deps come from npm either way — one lockfile, and Bun runs against it.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest, ubuntu-latest]
+        os: [macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, windows-latest, ubuntu-latest]
+        os: [macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -35,3 +35,16 @@ jobs:
       - run: npm ci
       - uses: oven-sh/setup-bun@v2
       - run: npm run bun:test
+
+  # @gpuix/native 0.6.0's linux-x64-gnu prebuild carries no TestGpuixRenderer —
+  # it ships without the test-support feature — so the suites cannot run here.
+  # This checks the binding still loads, which is what the demos need.
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: node -e "const n = require('@gpuix/native'); if (typeof n.GpuixRenderer !== 'function') { console.error('GpuixRenderer missing from the linux prebuild'); process.exit(1) } console.log('binding ok')"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,9 @@ Then open the PNG with the Read tool (Preview.app also reloads on write). Headle
   (reinserts reparent implicitly; nodes that leave the live tree are destroyed at commit and
   re-materialize if shown again), `setCustomProp` not `setCustomPropValue`, and
   `commitMutations?.()` only where it exists. 0.6.0 dropped the darwin-x64 / linux-arm64 /
-  win32-arm64 prebuilds — pin 0.5.x on those platforms. Its linux-x64-gnu binary also ships
-  without the test-support feature, so `TestGpuixRenderer` is undefined there and CI can only
-  check that the binding loads.
+  win32-arm64 prebuilds — pin 0.5.x on those platforms. `TestGpuixRenderer` does not exist on Linux at all —
+  gpuix gates `mod test_renderer` on macOS/Windows and builds Linux with `--no-default-features`
+  until wgpu grows image readback — so CI there can only check that the binding loads.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,9 @@ Then open the PNG with the Read tool (Preview.app also reloads on write). Headle
   (reinserts reparent implicitly; nodes that leave the live tree are destroyed at commit and
   re-materialize if shown again), `setCustomProp` not `setCustomPropValue`, and
   `commitMutations?.()` only where it exists. 0.6.0 dropped the darwin-x64 / linux-arm64 /
-  win32-arm64 prebuilds — pin 0.5.x on those platforms.
+  win32-arm64 prebuilds — pin 0.5.x on those platforms. Its linux-x64-gnu binary also ships
+  without the test-support feature, so `TestGpuixRenderer` is undefined there and CI can only
+  check that the binding loads.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,8 @@ does not exist — and `--import` installs the `.svelte` loader.
 
 ```bash
 npm install                # entire setup; @gpuix/native ships prebuilt, no Rust toolchain
-npm run demo               # all four demos at once
+npm run demo               # all four demos at once (via scripts/demo-all.js —
+                           # cmd.exe has no `&` ... `wait`)
 npm run demo:counter       # counter (hot-reloads on save)
 npm run demo:tictactoe
 npm run demo:hn            # Hacker News reader — live network data, scrolling
@@ -135,7 +136,8 @@ schedule its own commit on a microtask — otherwise a mutation with no native e
 resolved `fetch`, a timer) would sit in the queue until the next click. Native events run
 `dispatch` → `flushSync()` → `commit()` so the effects' mutations land in the same frame. `render_hot` watches the entry's
 directory and re-imports with a `?v=N` cache-buster; `plugin.js` propagates that query to child
-`.svelte` imports, or a reload would re-instantiate the root against stale children.
+`.svelte` imports, or a reload would re-instantiate the root against stale children — through a
+`file://` URL, since a bare Windows path parses as a URL scheme.
 
 **`style.js`** — Svelte hands over the `style` attribute as CSS *text*; GPUI wants a camelCase
 object with bare-number lengths. `12px` → `12`, while `50%`, `auto` and `#1e1e2e` stay strings. The

--- a/HOWTO.txt
+++ b/HOWTO.txt
@@ -56,6 +56,9 @@ Notes
   Same entry points, run through Bun, which preloads src/plugin.js via
   bunfig.toml instead of taking --import. Dependencies still come from
   npm install either way; CI runs both runtimes.
+- Linux runs the demos but not the tests: @gpuix/native 0.6.0's linux-x64-gnu
+  prebuild exports no TestGpuixRenderer (built without the test-support
+  feature), so the headless suites cannot construct one.
 - Windows/Linux have no frame loop (requiresTick() is false), so the renderer
   drains its mutation queue on a microtask instead — see set_auto_commit() and
   npm run test:autocommit.

--- a/HOWTO.txt
+++ b/HOWTO.txt
@@ -1,5 +1,5 @@
-HOWTO: run from a fresh clone (macOS, Apple Silicon)
-====================================================
+HOWTO: run from a fresh clone (macOS Apple Silicon, Windows x64, Linux x64)
+==========================================================================
 
 Needs Node.js 24 or newer, or Bun 1.4.0 or newer.
 
@@ -56,6 +56,14 @@ Notes
   Same entry points, run through Bun, which preloads src/plugin.js via
   bunfig.toml instead of taking --import. Dependencies still come from
   npm install either way; CI runs both runtimes.
+- Windows/Linux have no frame loop (requiresTick() is false), so the renderer
+  drains its mutation queue on a microtask instead — see set_auto_commit() and
+  npm run test:autocommit.
+- macOS vibrancy (windowBackground "blurred") is macOS-only. The liquid-glass
+  demo asks for plain "transparent" elsewhere and darkens its own panel, so the
+  window is still see-through; demo:glass-ffi's non-macOS path does the same.
+- npm run demo / npm run bun:demo fan out through scripts/demo-all.js rather
+  than a POSIX `&` ... `wait` chain, which cmd.exe does not understand.
 - Optional: npm run test:coverage runs Svelte's own custom-renderer samples if
   SVELTE_SAMPLES_DIR points at a svelte checkout's
   packages/svelte/tests/custom-renderers/samples directory.

--- a/HOWTO.txt
+++ b/HOWTO.txt
@@ -56,9 +56,9 @@ Notes
   Same entry points, run through Bun, which preloads src/plugin.js via
   bunfig.toml instead of taking --import. Dependencies still come from
   npm install either way; CI runs both runtimes.
-- Linux runs the demos but not the tests: @gpuix/native 0.6.0's linux-x64-gnu
-  prebuild exports no TestGpuixRenderer (built without the test-support
-  feature), so the headless suites cannot construct one.
+- Linux runs the demos but not the tests: gpuix compiles TestGpuixRenderer
+  only on macOS and Windows (it needs render_to_image, which the Vulkan/wgpu
+  backend lacks), so the headless suites cannot construct one there.
 - Windows/Linux have no frame loop (requiresTick() is false), so the renderer
   drains its mutation queue on a microtask instead — see set_auto_commit() and
   npm run test:autocommit.

--- a/examples/liquid-glass-ffi/main.js
+++ b/examples/liquid-glass-ffi/main.js
@@ -10,9 +10,14 @@ await render_hot(new URL('../liquid-glass/LiquidGlass.svelte', import.meta.url),
 	width: 400,
 	height: 780,
 	transparent: true,
-	windowBackground: glass ? 'transparent' : 'blurred',
+	// GPUI's window blur is the macOS fallback; elsewhere only plain transparency
+	// exists, so the panel carries a heavier scrim of its own.
+	windowBackground: glass || process.platform !== 'darwin' ? 'transparent' : 'blurred',
 	titlebarTransparent: true,
-	props: { glass: glass !== null }
+	props: {
+		glass: glass !== null,
+		...(glass || process.platform === 'darwin' ? {} : { scrim: 'rgba(22, 22, 34, 0.92)' })
+	}
 });
 
 if (glass) {

--- a/examples/liquid-glass/LiquidGlass.svelte
+++ b/examples/liquid-glass/LiquidGlass.svelte
@@ -1,5 +1,9 @@
 <script>
-	let { glass = false } = $props();
+	let {
+		glass = false,
+		scrim = 'rgba(22, 22, 34, 0.42)',
+		backing = 'GPUI window blur behind the panel'
+	} = $props();
 
 	let wifi = $state(true);
 	let bluetooth = $state(true);
@@ -77,7 +81,7 @@
 
 <div
 	style="display: flex; flex-direction: column; align-items: center; width: 100%; height: 100%;
-	       background-color: rgba(22, 22, 34, 0.42); padding: 22px; padding-top: 44px"
+	       background-color: {scrim}; padding: 22px; padding-top: 44px"
 	onmousemove={move}
 	onmouseup={release}
 >
@@ -265,7 +269,7 @@
 			<div style="color: rgba(255,255,255,0.35); font-size: 11px">
 				{glass
 					? 'actual Liquid Glass — NSGlassEffectView behind the window'
-					: 'glassmorphism — GPUI window blur behind the panel'}
+					: `glassmorphism — ${backing}`}
 			</div>
 		</div>
 	</div>

--- a/examples/liquid-glass/main.js
+++ b/examples/liquid-glass/main.js
@@ -1,10 +1,17 @@
 import { render_hot } from 'gpuix-svelte';
 
+// GPUI's window blur is macOS-only; elsewhere the window is merely transparent,
+// so the panel needs a heavier scrim of its own to read as frosted glass.
+const blurred = process.platform === 'darwin';
+
 render_hot(new URL('./LiquidGlass.svelte', import.meta.url), {
 	title: 'GPUIX + Svelte — Liquid Glass',
 	width: 400,
 	height: 780,
 	transparent: true,
-	windowBackground: 'blurred',
-	titlebarTransparent: true
+	windowBackground: blurred ? 'blurred' : 'transparent',
+	titlebarTransparent: true,
+	props: blurred
+		? {}
+		: { scrim: 'rgba(22, 22, 34, 0.92)', backing: 'a transparent window behind the panel' }
 });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"node"
 	],
 	"scripts": {
-		"demo": "npm run demo:counter & npm run demo:tictactoe & npm run demo:hn & npm run demo:glass & wait",
+		"demo": "node scripts/demo-all.js",
 		"demo:counter": "node --conditions custom-renderer --conditions development --import ./src/register.js examples/counter/main.js",
 		"demo:tictactoe": "node --conditions custom-renderer --conditions development --import ./src/register.js examples/tic-tac-toe/main.js",
 		"demo:hn": "node --conditions custom-renderer --conditions development --import ./src/register.js examples/hacker-news/main.js",
@@ -45,7 +45,7 @@
 		"test:smoke": "node --conditions custom-renderer --conditions development --import ./src/register.js test/smoke.js",
 		"test:autocommit": "node --conditions custom-renderer --conditions development --import ./src/register.js test/autocommit.js",
 		"test:coverage": "node --conditions custom-renderer --conditions development --import ./src/register.js test/coverage.js",
-		"bun:demo": "npm run bun:demo:counter & npm run bun:demo:tictactoe & npm run bun:demo:hn & npm run bun:demo:glass & wait",
+		"bun:demo": "node scripts/demo-all.js --bun",
 		"bun:demo:counter": "bun --conditions custom-renderer --conditions development examples/counter/main.js",
 		"bun:demo:tictactoe": "bun --conditions custom-renderer --conditions development examples/tic-tac-toe/main.js",
 		"bun:demo:hn": "bun --conditions custom-renderer --conditions development examples/hacker-news/main.js",

--- a/scripts/demo-all.js
+++ b/scripts/demo-all.js
@@ -1,0 +1,35 @@
+/**
+ * `demo:counter & demo:tictactoe & ... & wait` only works in a POSIX shell, and npm
+ * runs scripts through cmd.exe on Windows, so the fan-out lives here instead.
+ */
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const EXAMPLES = ['counter', 'tic-tac-toe', 'hacker-news', 'liquid-glass'];
+
+const bun = process.argv.includes('--bun');
+const root = new URL('../', import.meta.url);
+const conditions = ['--conditions', 'custom-renderer', '--conditions', 'development'];
+
+const children = EXAMPLES.map((name) => {
+	const entry = fileURLToPath(new URL(`examples/${name}/main.js`, root));
+	const args = bun
+		? [...conditions, entry]
+		: [...conditions, '--import', pathToFileURL(fileURLToPath(new URL('src/register.js', root))).href, entry];
+
+	return spawn(bun ? 'bun' : process.execPath, args, {
+		cwd: fileURLToPath(root),
+		stdio: 'inherit',
+		// Bun is a shim on PATH rather than a resolvable executable on Windows.
+		shell: bun && process.platform === 'win32'
+	});
+});
+
+const stop = () => {
+	for (const child of children) child.kill();
+};
+
+process.on('SIGINT', stop);
+process.on('SIGTERM', stop);
+process.on('exit', stop);

--- a/src/render.js
+++ b/src/render.js
@@ -6,7 +6,7 @@
 
 import { watch } from 'node:fs';
 import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { GpuixRenderer } from '@gpuix/native';
 import { mount, unmount, flushSync } from 'svelte';
 import renderer, {
@@ -161,10 +161,13 @@ export function render(Component, options = {}) {
  * @param {Parameters<typeof render>[1]} [options]
  */
 export async function render_hot(entry, options = {}) {
-	const path = entry instanceof URL ? fileURLToPath(entry) : entry;
+	// A bare Windows path is not a valid import specifier ("D:" parses as a URL
+	// scheme), so the cache-buster is appended to a file:// URL instead.
+	const url = entry instanceof URL ? entry : pathToFileURL(entry);
+	const path = fileURLToPath(url);
 
 	let version = 0;
-	const load = async () => (await import(`${path}?v=${++version}`)).default;
+	const load = async () => (await import(`${url.href}?v=${++version}`)).default;
 
 	render(await load(), options);
 

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -4,6 +4,8 @@
  */
 
 import { existsSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { TestGpuixRenderer } from '@gpuix/native';
 import { mount, flushSync } from 'svelte';
 import renderer, { set_native, create_root, commit, dispatch } from '../src/renderer.js';
@@ -89,7 +91,7 @@ for (let i = 0; i < 2; i++) {
 }
 console.log('after 2 adds:', JSON.stringify(native.getAllText()));
 
-const shot = '/tmp/gpuix-svelte-headless.png';
+const shot = join(tmpdir(), 'gpuix-svelte-headless.png');
 native.captureScreenshot(shot);
 console.log('screenshot:', shot);
 


### PR DESCRIPTION
Gets the library running on Windows (win32-x64, Node 24 and Bun 1.4), and widens CI to Windows and Linux.

Sits on top of 4ea2450 — the microtask drain fixed the one Windows bug that was reachable without these, but no demo could actually start on Windows to confirm it. The first commit here is what unblocks that.

## What was broken

- **`render_hot` could not import anything.** It appended the `?v=N` cache-buster to a bare path, and `D:\...` parses as a URL with scheme `d:`, so every demo died with `ERR_INVALID_URL_SCHEME` before a window opened.
- **`test:smoke` failed on the screenshot** — hardcoded `/tmp`, which does not exist on Windows.
- **`npm run demo` did not fan out.** npm runs scripts through cmd.exe on Windows, where `a & b & wait` runs the demos sequentially and then fails on `wait`. Replaced with `scripts/demo-all.js`.
- **The liquid-glass demo was opaque.** `windowBackground: "blurred"` is macOS vibrancy; off macOS it falls back to opaque. The window now asks for plain `transparent` there and the panel carries its own heavier scrim, so it still reads as frosted glass. Same for `demo:glass-ffi`'s non-macOS path. macOS behaviour is unchanged — `blurred` and the 0.42 scrim as before.

## Verified on Windows 11, win32-x64

`npm test` and `npm run bun:test` both green, including `test:autocommit`. All four demos render on Node and Bun; `demo:hn` pulls the live story list (the microtask drain doing its job), the glass clock ticks, hot reload remounts on save, and `npm run demo` opens all four with no orphans left behind. `@gpuix/native` installs prebuilt — no Rust or MSVC toolchain needed.

`demo:glass-ffi` falls back cleanly (it is macOS-only by design).

## CI

`node` and `bun` become a `[macos-14, windows-latest]` matrix, `fail-fast: false`. The headless `TestGpuixRenderer` does get a usable adapter on a GPU-less Windows runner — those jobs render for real, screenshot included.

Linux is a separate, smaller job, because **`TestGpuixRenderer` does not exist there** and every test dies on `TestGpuixRenderer is not a constructor`. Checked against the gpuix source: this is deliberate, not a mispublish. `packages/native/src/lib.rs` gates `mod test_renderer` on `any(target_os = "macos", target_os = "windows")`, and their CI builds Linux with `--no-default-features` — *"until wgpu image readback lands"*. The test renderer needs `render_to_image()`, which Metal and D3D have and the Vulkan/wgpu backend does not. The published binaries line up:

| prebuild | `TestGpuixRenderer` in the `.node` |
| --- | --- |
| darwin-arm64 | 139 hits |
| win32-x64-msvc | 5 hits |
| linux-x64-gnu | **0** |

`GpuixRenderer` is present on Linux, so the demos would run there — only the headless suites can't. The Linux job checks exactly that: the binding loads and `GpuixRenderer` is constructible. When wgpu readback lands it becomes a third matrix entry and the special case goes away.
