### PR TITLE
Give the control center a real titlebar off macOS

### DIFF
--- a/examples/liquid-glass-ffi/main.js
+++ b/examples/liquid-glass-ffi/main.js
@@ -13,10 +13,12 @@ await render_hot(new URL('../liquid-glass/LiquidGlass.svelte', import.meta.url),
 	// GPUI's window blur is the macOS fallback; elsewhere only plain transparency
 	// exists, so the panel carries a heavier scrim of its own.
 	windowBackground: glass || process.platform !== 'darwin' ? 'transparent' : 'blurred',
-	titlebarTransparent: true,
+	titlebarTransparent: process.platform === 'darwin',
 	props: {
 		glass: glass !== null,
-		...(glass || process.platform === 'darwin' ? {} : { scrim: 'rgba(22, 22, 34, 0.92)' })
+		...(process.platform === 'darwin'
+			? {}
+			: { scrim: 'rgba(22, 22, 34, 0.92)', padTop: 22 })
 	}
 });
 

--- a/examples/liquid-glass/LiquidGlass.svelte
+++ b/examples/liquid-glass/LiquidGlass.svelte
@@ -2,7 +2,9 @@
 	let {
 		glass = false,
 		scrim = 'rgba(22, 22, 34, 0.42)',
-		backing = 'GPUI window blur behind the panel'
+		backing = 'GPUI window blur behind the panel',
+		// Room for the traffic lights the transparent titlebar draws over.
+		padTop = 44
 	} = $props();
 
 	let wifi = $state(true);
@@ -81,7 +83,7 @@
 
 <div
 	style="display: flex; flex-direction: column; align-items: center; width: 100%; height: 100%;
-	       background-color: {scrim}; padding: 22px; padding-top: 44px"
+	       background-color: {scrim}; padding: 22px; padding-top: {padTop}px"
 	onmousemove={move}
 	onmouseup={release}
 >

--- a/examples/liquid-glass/main.js
+++ b/examples/liquid-glass/main.js
@@ -1,17 +1,26 @@
 import { render_hot } from 'gpuix-svelte';
 
 // GPUI's window blur is macOS-only; elsewhere the window is merely transparent,
-// so the panel needs a heavier scrim of its own to read as frosted glass.
-const blurred = process.platform === 'darwin';
+// so the panel needs a heavier scrim of its own to read as frosted glass. The
+// titlebar goes transparent only where there are traffic lights to draw under —
+// nothing here can close or move a window, so hiding the real chrome would
+// strand it.
+const mac = process.platform === 'darwin';
 
 render_hot(new URL('./LiquidGlass.svelte', import.meta.url), {
-	title: 'GPUIX + Svelte — Liquid Glass',
+	// The titlebar is visible off macOS, and what it shows there is plain window
+	// transparency, not Apple's material.
+	title: mac ? 'GPUIX + Svelte — Liquid Glass' : 'GPUIX + Svelte — Transparency',
 	width: 400,
 	height: 780,
 	transparent: true,
-	windowBackground: blurred ? 'blurred' : 'transparent',
-	titlebarTransparent: true,
-	props: blurred
+	windowBackground: mac ? 'blurred' : 'transparent',
+	titlebarTransparent: mac,
+	props: mac
 		? {}
-		: { scrim: 'rgba(22, 22, 34, 0.92)', backing: 'a transparent window behind the panel' }
+		: {
+				scrim: 'rgba(22, 22, 34, 0.92)',
+				backing: 'a transparent window behind the panel',
+				padTop: 12
+			}
 });


### PR DESCRIPTION
Three small fixes to the control center demo off macOS, on top of #2.

`titlebarTransparent: true` exists so an app can draw its own chrome *under* the macOS traffic lights, and the panel's `padding-top: 44px` was the room it leaves them. There are no traffic lights on Windows — so that 44px was just a dead band at the top, and the window had no titlebar either, which means nothing could close, move or minimise it. `GpuixRenderer` exposes no close/minimise/drag method, so drawing our own buttons was not an option; they would have been dead pixels.

Off macOS the demo now:

- keeps the **system titlebar** (`titlebarTransparent: mac`)
- drops the top padding to **12px** via a new `padTop` prop (macOS keeps 44)
- is titled **"GPUIX + Svelte — Transparency"**, since what it shows there is plain window transparency, not Apple's material

macOS is untouched: `blurred`, transparent titlebar, 44px, and the original title all still key off `process.platform === 'darwin'`. `demo:glass-ffi` gets the same titlebar and padding treatment but keeps its name — it is specifically about the real thing.

Checked on Windows 11: titlebar present and working, window still see-through, no dead band. `npm test` and `npm run bun:test` both green.
