### PR TITLE
Give the Windows .exe its icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,9 +94,17 @@ there, and `production` only takes effect together with the `process.env.NODE_EN
 Bun implies `development` otherwise and esm-env lists it first. `@gpuix/native`'s loader bundles
 as-is and Bun embeds the host's `.node` prebuild on its own, which is why a binary is built on the OS
 it targets (npm only installs the host prebuild). `GPUIX_SVELTE_RENDERER` is a build-time variable on
-this path. CI compiles on all three prebuild platforms but never launches the result. The `.app`'s
-icon is `examples/tic-tac-toe/icon.png`, rasterized at 1024 px from the `icon.svg` beside it; `--app`
-cuts it into an `.icns` with `sips` + `iconutil`, which ship with macOS.
+this path. CI compiles on all three prebuild platforms but never launches the result. The icon on
+both platforms is `examples/tic-tac-toe/icon.png`, rasterized at 1024 px from the `icon.svg` beside
+it; `--app` cuts it into an `.icns` with `sips` + `iconutil`, which ship with macOS. On Windows it
+becomes an executable resource instead of a bundled file, so `write_ico` runs *before* the build and
+passes the result as `compile.windows.icon`: PowerShell's `System.Drawing` stands in for `sips`, and
+the `.ico` is assembled here — a 6-byte header plus one 16-byte entry per size over the PNGs
+themselves, which Windows reads uncompressed-or-PNG since Vista. It lives in `dist/` only for the
+length of the build. Its sizes are ordered **largest first**, working around a Bun bug: Bun swaps the
+`RT_ICON` payloads for ours but leaves its own `IDI_MYICON` group directory behind, still pointing at
+`RT_ICON #1`. A string-named group sorts ahead of our numeric one in the PE, so `#1` is the icon
+Explorer actually resolves and scales to every size — 16px first meant a blurry upscale everywhere.
 
 ## Hard constraints
 

--- a/HOWTO.txt
+++ b/HOWTO.txt
@@ -61,6 +61,9 @@ Notes
   (dist\tictactoe.exe on Windows) with Bun.build({ compile }); npm run
   compile:app also wraps it as a macOS .app. Bun-only, and built per OS —
   npm installs only the host's prebuilt addon, so there is no cross-compiling.
+  Both carry examples/tic-tac-toe/icon.png: an .icns inside the .app, an .ico
+  resource in the .exe, cut with sips/iconutil on macOS and PowerShell's
+  System.Drawing on Windows.
 - Linux runs the demos but not the tests: gpuix compiles TestGpuixRenderer
   only on macOS and Windows (it needs render_to_image, which the Vulkan/wgpu
   backend lacks); on Linux its constructor throws, so the headless suites

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ npm run compile        # tic-tac-toe → dist/tictactoe (dist\tictactoe.exe on W
 npm run compile:app    # macOS: additionally wraps it as dist/Tic-tac-toe.app
 ```
 
-The result is ~80 MB — the Bun runtime, the Svelte runtime and the 17 MB GPUI addon. It is built
-for the machine it runs on: run the same command on macOS (arm64), Linux (x64) or Windows (x64) to
-get that platform's binary. There is no cross-compiling, since npm only installs the addon prebuilt
-for the host. The macOS binary is unsigned, so a downloaded copy needs a right-click → Open once.
+The result is 80–100 MB depending on the platform — the Bun runtime, the Svelte runtime and the
+17 MB GPUI addon. It is built for the machine it runs on: run the same command on macOS (arm64),
+Linux (x64) or Windows (x64) to get that platform's binary. There is no cross-compiling, since npm
+only installs the addon prebuilt for the host. Both the `.exe` and the `.app` carry the example's
+icon; the Windows one also starts without a console window. The macOS binary is unsigned, so a
+downloaded copy needs a right-click → Open once.
 
 ## Use in your own project
 

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -5,7 +5,7 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import { chmodSync, copyFileSync, mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,6 +25,7 @@ const dist = join(root, 'dist');
 const binary = join(dist, process.platform === 'win32' ? 'tictactoe.exe' : 'tictactoe');
 const bundle = join(dist, 'Tic-tac-toe.app');
 const icon = join(root, 'examples/tic-tac-toe/icon.png');
+const ico = join(dist, 'AppIcon.ico');
 
 const PLIST = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -68,6 +69,10 @@ rmSync(binary, { force: true });
 rmSync(bundle, { recursive: true, force: true });
 mkdirSync(dist, { recursive: true });
 
+// Unlike the .app's icon, this one is a resource inside the executable, so it has
+// to exist before the build rather than after it.
+if (process.platform === 'win32') write_ico(icon, ico);
+
 const result = await Bun.build({
 	entrypoints: [join(root, 'examples/tic-tac-toe/standalone.js')],
 	target: 'bun',
@@ -83,7 +88,7 @@ const result = await Bun.build({
 		// A bunfig.toml or .env beside the launched binary (this repo's, say) must not reconfigure it.
 		autoloadBunfig: false,
 		autoloadDotenv: false,
-		...(process.platform === 'win32' && { windows: { hideConsole: true } })
+		...(process.platform === 'win32' && { windows: { hideConsole: true, icon: ico } })
 	}
 });
 
@@ -96,6 +101,8 @@ if (components === 0) {
 	console.error('[compile] no .svelte file went through the plugin');
 	process.exit(1);
 }
+
+rmSync(ico, { force: true });
 
 // The output is Bun's own executable plus the payload, and the addon is at least
 // 17 MB on every platform, so anything closer to bare Bun than that lost it.
@@ -134,6 +141,61 @@ function write_icns(png, out) {
 		run('sips', ['-z', `${points * 2}`, `${points * 2}`, png, '--out', join(iconset, `icon_${points}x${points}@2x.png`)]);
 	}
 	run('iconutil', ['-c', 'icns', iconset, '-o', out]);
+	rmSync(iconset, { recursive: true, force: true });
+}
+
+// The Windows counterpart to write_icns: System.Drawing is what every Windows
+// PowerShell has in place of sips, and the .ico around the PNGs it cuts is a
+// 6-byte header plus a 16-byte entry each, which Windows has read since Vista.
+function write_ico(png, out) {
+	// Largest first, because Bun leaves its own `IDI_MYICON` group behind pointing at
+	// RT_ICON #1 and a string-named group outranks ours: whatever lands first is the
+	// icon Explorer shows, upscaled to every size it needs.
+	const sizes = [256, 128, 64, 48, 32, 16];
+	const iconset = join(dist, 'AppIcon.icoset');
+	rmSync(iconset, { recursive: true, force: true });
+	mkdirSync(iconset);
+
+	const script = join(iconset, 'resize.ps1');
+	writeFileSync(
+		script,
+		`Add-Type -AssemblyName System.Drawing
+$source = [System.Drawing.Image]::FromFile('${png}')
+foreach ($size in ${sizes.join(', ')}) {
+	$bitmap = New-Object System.Drawing.Bitmap $size, $size, ([System.Drawing.Imaging.PixelFormat]::Format32bppArgb)
+	$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+	$graphics.InterpolationMode = [System.Drawing.Drawing2D.InterpolationMode]::HighQualityBicubic
+	$graphics.PixelOffsetMode = [System.Drawing.Drawing2D.PixelOffsetMode]::HighQuality
+	$graphics.Clear([System.Drawing.Color]::Transparent)
+	$graphics.DrawImage($source, (New-Object System.Drawing.Rectangle 0, 0, $size, $size))
+	$graphics.Dispose()
+	$bitmap.Save((Join-Path '${iconset}' "$size.png"), [System.Drawing.Imaging.ImageFormat]::Png)
+	$bitmap.Dispose()
+}
+$source.Dispose()
+`
+	);
+	run('powershell', ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', script]);
+
+	const images = sizes.map((size) => readFileSync(join(iconset, `${size}.png`)));
+	const header = Buffer.alloc(6 + 16 * sizes.length);
+	header.writeUInt16LE(1, 2);
+	header.writeUInt16LE(sizes.length, 4);
+
+	let offset = header.length;
+	sizes.forEach((size, i) => {
+		const entry = 6 + i * 16;
+		// 256 doesn't fit the byte, and 0 is how the format spells it.
+		header.writeUInt8(size === 256 ? 0 : size, entry);
+		header.writeUInt8(size === 256 ? 0 : size, entry + 1);
+		header.writeUInt16LE(1, entry + 4);
+		header.writeUInt16LE(32, entry + 6);
+		header.writeUInt32LE(images[i].length, entry + 8);
+		header.writeUInt32LE(offset, entry + 12);
+		offset += images[i].length;
+	});
+
+	writeFileSync(out, Buffer.concat([header, ...images]));
 	rmSync(iconset, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
`npm run compile` produced a Windows binary with the generic executable icon. This gives it
`examples/tic-tac-toe/icon.png`, the same art the macOS `.app` already uses.

## What changed

`scripts/compile.js` grows a `write_ico`, the Windows counterpart to the existing `write_icns`:

- PowerShell's `System.Drawing` resizes the 1024px source to 16/32/48/64/128/256, standing in for
  macOS's `sips` — both are host tools that ship with the OS.
- The `.ico` container is assembled in JS: a 6-byte header plus one 16-byte directory entry per
  size, over the PNGs themselves, which Windows has read since Vista.
- It runs *before* `Bun.build` and the file is deleted after, because the Windows icon is a
  resource compiled into the executable rather than a file copied into a bundle. `dist/` still
  ends up holding only the binary.

## The largest-first ordering is load-bearing

Sizes are written **largest first**, working around a Bun bug. `--windows-icon` swaps the
`RT_ICON` payloads for ours and adds a correct numeric `RT_GROUP_ICON`, but leaves Bun's own
string-named `IDI_MYICON` group behind, still pointing at `RT_ICON #1`:

```
GROUP "IDI_MYICON"   1 entry:  claims 256px, 270600 bytes -> RT_ICON #1   <- Bun's leftover
GROUP #0             6 entries: 256,128,64,48,32,16       -> #1..#6       <- ours, correct
```

A string-named resource sorts ahead of a numeric one in the PE resource directory, so `IDI_MYICON`
is the group Windows actually resolves. With ascending sizes `RT_ICON #1` was the 16x16 image, and
Explorer upscaled it to every size — the app looked like it had a blurry low-resolution icon.
Largest-first makes `#1` the 256px image, so the stale group lands on something worth scaling down.

Ascending order is the natural thing to write, and nothing fails if it is restored, so the reason
is commented at the `sizes` array and written up in `CLAUDE.md`.

## Verification

On Windows 11 x64, Bun 1.4.0, against a rebuilt `dist\tictactoe.exe`:

- All six sizes are present in the PE as `RT_ICON`, byte-identical to what `write_ico` generated.
- Rendered through `IShellItemImageFactory::GetImage(SIIGBF_ICONONLY)` from a **freshly-named copy**
  (so no icon-cache entry can exist): sharp at 256, correct at 32.
- Ruled out the icon cache — the uncached path shows the same thing — and ruled out a malformed
  `.ico`, since `LoadImage(..., LR_LOADFROMFILE)` renders the file itself sharp at 256.
- `npm test` and `npm run bun:test` pass; the compiled exe still runs standalone.

macOS is untouched: `write_ico` is called only on `win32`, and `--app` still refuses to run
anywhere else.

## Also

`README.md` claimed the binary is ~80 MB, which is the macOS figure — Windows is 101 MB. Now
stated as a range.

## Not covered by tests

CI compiles on all three platforms but never launches or inspects the result, so this is verified
by hand. A regression check would need PE resource parsing in CI; if Bun fixes `IDI_MYICON`, the
workaround simply stops mattering rather than breaking.
