### PR TITLE
perf: virtual timeline on GPUI's <virtual-list>, throttled scrollbar thumb

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ npm run test:compile       # single test — the ?v=N cache-buster reaches every
 npm run test:css           # single test — <style> class rules: specificity, inline wins, :hover, class: toggles
 npm run test:module        # single test — a .svelte.ts runes module compiles and is one shared instance
 npm run test:vars          # single test — var() in class rules and inline styles, set_css_vars restyles in one batch
-npm run test:scroller      # single test — the shipped Scroller: wheel, thumb drag, follow, scroll={false}
+npm run test:scroller      # single test — the shipped Scroller: wheel, thumb drag, follow, scroll={false}, virtual
 npm run test:hitbox        # single test — hitbox="self" shielding through real hit testing, <svg> colour inheritance
 npm run test:window-keys   # single test — on_window_key, the editing flag, remount survival
 npm run test:portal        # single test — <Portal> paints on top, tears down with its {#if}, orders by mount
@@ -222,10 +222,16 @@ compile.ts   .svelte → JS, runtime-agnostic  ─┘
 
 `src/components/` ships `.svelte` files as-is; the consumer's loader compiles them, and their
 `import ... from 'gpuix-svelte'` resolves through the package's own `exports` from anywhere.
-`Scroller` (props `gap`, `pad`, `grow`, `scroll`, `follow`, `testid`) is the scroll column with a
-drawn thumb that the tutorial, the styling playground and Substrate all use — GPUI paints no
-scrollbar and captures no pointer, so it measures `getElementBounds`/`getScrollOffset` on a timer
-and drags on a panel-sized overlay. Its colours are `var(--scroller-thumb, …)` /
+`Scroller` (props `gap`, `pad`, `grow`, `scroll`, `follow`, `virtual`, `estimate`, `testid`) is
+the scroll column with a drawn thumb that the tutorial, the styling playground and Substrate all
+use — GPUI paints no scrollbar and captures no pointer, so it measures
+`getElementBounds`/`getScrollOffset` on a timer and drags on a panel-sized overlay; the thumb
+restyle after a wheel event is throttled to one per 50 ms because each one is a full native frame.
+A plain scroll container lays out and paints every child every frame, so `virtual` swaps in GPUI's
+`<virtual-list>` (each direct child a row, which needs `width: 100%`; `estimate` the unmeasured-row height hint; `follow` →
+`followTail`; thumb from `getListScrollTop` and the `visibleRange` event, drag via `scrollToItem`;
+the list host has no tracked bounds, so measure its wrapper). Substrate's timeline and kind lists
+use it. Its colours are `var(--scroller-thumb, …)` /
 `var(--scroller-thumb-hover, …)`, so a palette sets them and the fallbacks are the Catppuccin
 greys. `Portal` is a window-sized `position: absolute; pointer-events: none` wrapper carrying the
 renderer's `portal` attribute: the shadow node stays exactly where Svelte put it (so Svelte's

--- a/README.md
+++ b/README.md
@@ -318,6 +318,15 @@ without a thumb, `follow` to keep the bottom in view while content grows (a stre
 `testid`. Colours come from `var(--scroller-thumb)` and `var(--scroller-thumb-hover)`, with greys
 as fallbacks.
 
+A plain scroll column still lays out and paints every child on every frame, on screen or not, so a
+long list gets slow in proportion to its length. `virtual` renders GPUI's native `<virtual-list>`
+instead: every direct child is one row (wrap each item in a `div` with `width: 100%`, since rows
+size to their content and the list has no `gap`), GPUI builds and paints only the rows near the viewport, `estimate` is the
+height hint for rows it has not measured yet, and `follow` becomes the list's own tail-following.
+The thumb then works in rows rather than pixels, from `getListScrollTop` and the `visibleRange`
+event, and a drag scrolls with `scrollToItem`. Substrate's timeline is the example: 50 cards went
+from ~24 ms to ~1.4 ms per frame.
+
 **`Portal`** — paint order is document order, so a modal, toast or menu had to be the root's last
 child. `<Portal>` renders from wherever the overlay is needed and still paints on top: the renderer
 hangs only the native node off the root, so Svelte's `{#if}` blocks and teardown are untouched. The

--- a/examples/second-brain/routes/Everything.svelte
+++ b/examples/second-brain/routes/Everything.svelte
@@ -8,18 +8,19 @@
 	import { push } from '../lib/router.svelte.ts';
 	import { focus } from '../lib/ui.svelte.ts';
 
+	const PAGE = 200;
 	let page = $state(1);
-	const visible = $derived(data.items.slice(0, page * 50));
+	const visible = $derived(data.items.slice(0, page * PAGE));
 </script>
 
 <div class="route">
 	<div class="capture"><CaptureBox /></div>
-	<Scroller pad="0 20px 20px 20px" gap={8} testid="timeline">
+	<Scroller virtual estimate={100} pad="0 20px 20px 20px" testid="timeline">
 		{#each visible as item (item.id)}
-			<ItemCard {item} onopen={() => push(`/item/${item.id}`)} />
+			<div class="row"><ItemCard {item} onopen={() => push(`/item/${item.id}`)} /></div>
 		{/each}
 		{#if visible.length < data.items.length}
-			<Button label="Load more" onclick={() => page++} />
+			<div class="row"><Button label="Load more" onclick={() => page++} /></div>
 		{/if}
 		{#if data.items.length === 0}
 			<EmptyState
@@ -34,4 +35,5 @@
 <style>
 	.route { display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
 	.capture { padding: 16px 20px 10px 20px; }
+	.row { display: flex; flex-direction: column; width: 100%; padding-bottom: 8px; }
 </style>

--- a/examples/second-brain/routes/Kind.svelte
+++ b/examples/second-brain/routes/Kind.svelte
@@ -23,7 +23,7 @@
 		<KindBadge {kind} />
 		<div class="count">{items.length} item{items.length === 1 ? '' : 's'}</div>
 	</div>
-	<Scroller pad="0 20px 20px 20px" gap={kind === 'image' ? 12 : 8}>
+	<Scroller virtual={kind !== 'image'} estimate={100} pad="0 20px 20px 20px" gap={12}>
 		{#if items.length === 0}
 			<EmptyState title={COPY[kind][0]} body={COPY[kind][1]} />
 		{:else if kind === 'image'}
@@ -42,7 +42,7 @@
 			</div>
 		{:else}
 			{#each items as item (item.id)}
-				<ItemCard {item} onopen={() => push(`/item/${item.id}`)} />
+				<div class="row"><ItemCard {item} onopen={() => push(`/item/${item.id}`)} /></div>
 			{/each}
 		{/if}
 	</Scroller>
@@ -51,6 +51,7 @@
 <style>
 	.route { display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
 	.head { display: flex; flex-direction: row; align-items: center; gap: 10px; padding: 16px 20px 12px 20px; font-size: 12px; line-height: 16px; user-select: none; color: var(--inkFaint); }
+	.row { display: flex; flex-direction: column; width: 100%; padding-bottom: 8px; }
 	.grid { display: flex; flex-direction: row; flex-wrap: wrap; gap: 12px; }
 	.tile { display: flex; flex-direction: column; gap: 6px; width: 172px; padding: 8px; border-radius: 10px; border-width: 1px; cursor: pointer; user-select: none; background-color: var(--surface); border-color: var(--border); }
 	.tile:hover { background-color: var(--raised); border-color: var(--borderStrong); }

--- a/examples/second-brain/test/smoke.ts
+++ b/examples/second-brain/test/smoke.ts
@@ -26,6 +26,7 @@ import {
 	click_test_id,
 	press,
 	painted,
+	all_text,
 	screenshot,
 	check,
 	finish
@@ -54,7 +55,8 @@ async function tap(text: string, opts?: ClickOptions) {
 await wait();
 await wait();
 check('brand painted', painted().includes('Substrate'));
-check('seeded note painted', painted().includes('Compost notes'));
+// Off-screen rows of the virtual timeline are retained but not painted.
+check('seeded note in the timeline', all_text().some((t) => t.includes('Compost notes')));
 check('sidebar counts painted', painted().includes('Everything'));
 
 // The palette reaches every <style> through set_css_vars, so a mode switch is one restyle.
@@ -127,7 +129,7 @@ await wait();
 check('confirm deletes the item', app.get_item(note.id), null);
 check('delete navigates back', route.path, '/');
 await wait();
-check('deleted note gone from the timeline', painted().includes('Buy compost for the raised beds'), false);
+check('deleted note gone from the timeline', all_text().some((t) => t.includes('Buy compost for the raised beds')), false);
 
 console.log('screenshot:', screenshot(join(tmpdir(), 'substrate-smoke.png')));
 

--- a/src/components/Scroller.svelte
+++ b/src/components/Scroller.svelte
@@ -33,9 +33,13 @@
 	let thumb = $state({ top: 0, height: 0 });
 	let drag = $state<{ y: number; offset: number } | null>(null);
 	let last_total = 0;
-	// Rows GPUI last reported in view: a virtual list has no content to measure, so
-	// the thumb works in rows, scaled by the average painted row height.
+	// A virtual list has no content to measure, so the thumb works in rows, scaled by
+	// the average painted row height. GPUI reports one row more or less in view from
+	// event to event, so the scale is a running mean of the reports, seeded with
+	// `estimate` at the weight of PRIOR reports so the first few barely move it.
 	let in_view = 0;
+	let reports = 0;
+	const PRIOR = 8;
 
 	type Metrics = { native: Native; viewport: number; total: number; offset: number; per: number };
 
@@ -53,7 +57,7 @@
 			const top = native.getListScrollTop(column.nativeId);
 			const count = rows();
 			if (!top || !top[2] || count === 0) return null;
-			const per = in_view > 0 ? top[2] / in_view : estimate;
+			const per = top[2] / ((PRIOR * (top[2] / estimate) + in_view) / (PRIOR + reports));
 			return { native, viewport: top[2], total: count * per, offset: -(top[0] * per + top[1]), per };
 		}
 
@@ -136,7 +140,11 @@
 	}
 
 	function on_range(e: GpuixEvent) {
-		in_view = (e.endIndex ?? 0) - (e.startIndex ?? 0);
+		const rows = (e.endIndex ?? 0) - (e.startIndex ?? 0);
+		if (rows > 0) {
+			in_view += rows;
+			reports++;
+		}
 		refresh();
 	}
 

--- a/src/components/Scroller.svelte
+++ b/src/components/Scroller.svelte
@@ -11,32 +11,73 @@
 		grow = 1,
 		scroll = true,
 		follow = false,
+		virtual = false,
+		estimate = 80,
 		testid = null
-	}: { children: Snippet; gap?: number; pad?: string; grow?: number; scroll?: boolean; follow?: boolean; testid?: string | null } = $props();
+	}: {
+		children: Snippet;
+		gap?: number;
+		pad?: string;
+		grow?: number;
+		scroll?: boolean;
+		follow?: boolean;
+		/** Render a native `<virtual-list>`: each direct child is a row, and only rows near the viewport are built. */
+		virtual?: boolean;
+		/** Height hint for rows the list has not measured yet (virtual only). */
+		estimate?: number;
+		testid?: string | null;
+	} = $props();
 
 	let column: ShadowNode | null = null;
 	let content: ShadowNode | null = null;
 	let thumb = $state({ top: 0, height: 0 });
 	let drag = $state<{ y: number; offset: number } | null>(null);
 	let last_total = 0;
+	// Rows GPUI last reported in view: a virtual list has no content to measure, so
+	// the thumb works in rows, scaled by the average painted row height.
+	let in_view = 0;
 
-	type Metrics = { native: Native; viewport: number; total: number; offset: number };
+	type Metrics = { native: Native; viewport: number; total: number; offset: number; per: number };
+
+	function rows() {
+		let n = 0;
+		for (let c = column?.first ?? null; c; c = c.next) if (c.nativeId !== null) n++;
+		return n;
+	}
 
 	function metrics(): Metrics | null {
 		const native = get_native();
-		if (!native || !column?.nativeId || !content?.nativeId) return null;
+		if (!native || !column?.nativeId) return null;
 
+		if (virtual) {
+			const top = native.getListScrollTop(column.nativeId);
+			const count = rows();
+			if (!top || !top[2] || count === 0) return null;
+			const per = in_view > 0 ? top[2] / in_view : estimate;
+			return { native, viewport: top[2], total: count * per, offset: -(top[0] * per + top[1]), per };
+		}
+
+		if (!content?.nativeId) return null;
 		const viewport = native.getElementBounds(column.nativeId)?.[3];
 		const total = native.getElementBounds(content.nativeId)?.[3];
 		if (!viewport || !total) return null;
 
-		return { native, viewport, total, offset: native.getScrollOffset(column.nativeId)?.[1] ?? 0 };
+		return { native, viewport, total, offset: native.getScrollOffset(column.nativeId)?.[1] ?? 0, per: 0 };
+	}
+
+	function scroll_to(m: Metrics, offset: number) {
+		if (!virtual) {
+			m.native.scrollTo(column!.nativeId!, 0, offset);
+			return;
+		}
+		const index = -offset / m.per;
+		m.native.scrollToItem(column!.nativeId!, Math.floor(index), (index - Math.floor(index)) * m.per);
 	}
 
 	function place(m: Metrics, offset: number) {
 		let top = 0;
 		let height = 0;
-		if (scroll && m.total > m.viewport) {
+		if ((scroll || virtual) && m.total > m.viewport) {
 			const h = Math.max(24, (m.viewport / m.total) * m.viewport);
 			height = Math.round(h);
 			top = Math.round((-offset / (m.total - m.viewport)) * (m.viewport - h));
@@ -44,13 +85,14 @@
 		if (top !== thumb.top || height !== thumb.height) thumb = { top, height };
 	}
 
-	// `follow` keeps the bottom in view while content grows (a streaming reply).
+	// `follow` keeps the bottom in view while content grows (a streaming reply);
+	// a virtual list does that natively through `followTail`.
 	function update() {
 		const m = metrics();
 		if (!m) return;
-		if (follow && m.total !== last_total && m.total > m.viewport) {
+		if (!virtual && follow && m.total !== last_total && m.total > m.viewport) {
 			const bottom = m.viewport - m.total;
-			m.native.scrollTo(column!.nativeId!, 0, bottom);
+			scroll_to(m, bottom);
 			place(m, bottom);
 		} else {
 			place(m, m.offset);
@@ -61,7 +103,7 @@
 	function grab(e: GpuixEvent) {
 		if (e.button !== 0) return;
 		const m = metrics();
-		if (m) drag = { y: e.y, offset: m.offset };
+		if (m) drag = { y: e.y!, offset: m.offset };
 	}
 
 	// GPUI does not capture the pointer, so the drag runs on a panel-sized overlay
@@ -78,27 +120,55 @@
 		const travel = m.viewport - thumb.height;
 		const wanted = drag.offset - ((e.y! - drag.y) / travel) * (m.total - m.viewport);
 		const offset = Math.max(m.viewport - m.total, Math.min(0, wanted));
-		m.native.scrollTo(column!.nativeId!, 0, offset);
+		scroll_to(m, offset);
 		place(m, offset);
 	}
 
-	// The offset moves after the wheel event returns, and content changes height
-	// without any event, so the thumb is re-measured on a timer too.
-	const refresh = () => setTimeout(update, 16);
+	// Every thumb restyle is a full native frame, so a wheel stream gets at most one
+	// per 50 ms rather than one per event; the offset has long moved by then.
+	let pending: ReturnType<typeof setTimeout> | null = null;
+	function refresh() {
+		if (pending !== null) return;
+		pending = setTimeout(() => {
+			pending = null;
+			update();
+		}, 50);
+	}
 
+	function on_range(e: GpuixEvent) {
+		in_view = (e.endIndex ?? 0) - (e.startIndex ?? 0);
+		refresh();
+	}
+
+	// Content changes height without any event, so the thumb is re-measured on a timer too.
 	$effect(() => {
-		if (!scroll && !follow) return;
+		if (!scroll && !follow && !virtual) return;
 		const timer = setInterval(update, follow ? 100 : 250);
 		return () => clearInterval(timer);
 	});
 </script>
 
 <div class="wrap" style="flex-grow: {grow}">
-	<div {@attach (node: ShadowNode) => (column = node)} onscroll={refresh} class="column" class:fixed={!scroll} testId={testid}>
-		<div {@attach (node: ShadowNode) => (content = node)} class="content" class:fixed={!scroll} style="gap: {gap}px; padding: {pad}">
-			{@render children()}
+	{#if virtual}
+		<div class="inset" style="padding: {pad}">
+			<virtual-list
+				{@attach (node: ShadowNode) => (column = node)}
+				onvisiblerange={on_range}
+				class="list"
+				estimatedItemHeight={estimate}
+				followTail={follow}
+				testId={testid}
+			>
+				{@render children()}
+			</virtual-list>
 		</div>
-	</div>
+	{:else}
+		<div {@attach (node: ShadowNode) => (column = node)} onscroll={refresh} class="column" class:fixed={!scroll} testId={testid}>
+			<div {@attach (node: ShadowNode) => (content = node)} class="content" class:fixed={!scroll} style="gap: {gap}px; padding: {pad}">
+				{@render children()}
+			</div>
+		</div>
+	{/if}
 
 	<div class="gutter">
 		<div
@@ -122,6 +192,8 @@
 	.column.fixed { overflow-y: hidden; }
 	.content { display: flex; flex-direction: column; }
 	.content.fixed { flex-grow: 1; min-height: 0; }
+	.inset { display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
+	.list { display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
 	.gutter { position: absolute; top: 0; right: 0; bottom: 0; width: 8px; pointer-events: none; }
 	.thumb { position: absolute; left: 0; width: 8px; border-radius: 4px; cursor: default; user-select: none; background-color: var(--scroller-thumb, #585b70); }
 	.thumb:hover { background-color: var(--scroller-thumb-hover, #7f849c); }

--- a/src/events.ts
+++ b/src/events.ts
@@ -25,7 +25,9 @@ export const GPUI_EVENTS: readonly string[] = [
 	'blur',
 	'scroll',
 	// `highlight={{ query }}` on div/text reports its match count
-	'highlight'
+	'highlight',
+	// `<virtual-list>` reports the rows it has in view instead of a scroll offset
+	'visibleRange'
 ];
 
 /** Not element events: they arrive on the id handed to `setWindowKeyEvents` (see `on_window_key`). */

--- a/test/Tall.svelte
+++ b/test/Tall.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import Scroller from 'gpuix-svelte/components/Scroller.svelte';
 
-	let { rows = 30, follow = false, scroll = true }: { rows?: number; follow?: boolean; scroll?: boolean } = $props();
+	let { rows = 30, follow = false, scroll = true, virtual = false }: { rows?: number; follow?: boolean; scroll?: boolean; virtual?: boolean } = $props();
 	const items = $derived(Array.from({ length: rows }, (_, i) => i));
 </script>
 
 <div style="display: flex; flex-direction: row; width: 300px; height: 200px">
-	<Scroller testid="list" gap={0} {follow} {scroll}>
+	<Scroller testid="list" gap={0} {follow} {scroll} {virtual} estimate={40}>
 		{#each items as i (i)}
 			<div style="height: 40px; min-height: 40px">row {i}</div>
 		{/each}

--- a/test/Tall.svelte
+++ b/test/Tall.svelte
@@ -8,7 +8,7 @@
 <div style="display: flex; flex-direction: row; width: 300px; height: 200px">
 	<Scroller testid="list" gap={0} {follow} {scroll} {virtual} estimate={40}>
 		{#each items as i (i)}
-			<div style="height: 40px; min-height: 40px">row {i}</div>
+			<div style="height: {virtual ? (i % 2 ? 90 : 30) : 40}px; min-height: {virtual ? (i % 2 ? 90 : 30) : 40}px; width: 100%">row {i}</div>
 		{/each}
 	</Scroller>
 </div>

--- a/test/scroller.ts
+++ b/test/scroller.ts
@@ -4,7 +4,7 @@
  * This runs the wheel, the drag and `follow` through the real hit testing.
  */
 
-import { mount_headless, find_test_id, bounds, wait, drain, settle, check, finish } from 'gpuix-svelte/test';
+import { mount_headless, find, find_test_id, bounds, wait, drain, settle, painted, all_text, check, finish } from 'gpuix-svelte/test';
 
 const Tall = (await import('./Tall.svelte')).default;
 
@@ -25,8 +25,8 @@ check('with the package colour, nothing having set --scroller-thumb', thumb().st
 
 native.simulateScrollWheel(cx + cw / 2, cy + ch / 2, 0, -120);
 drain();
-// The offset moves after the wheel event returns; the thumb follows a beat later.
-await wait(40);
+// The offset moves after the wheel event returns; the thumb follows on its 50 ms throttle.
+await wait(80);
 check('a wheel scrolls the column', offset() < 0, true);
 const t1 = bounds(thumb())!;
 check('and the thumb moves down', t1[1] > t0[1], true);
@@ -54,5 +54,34 @@ check('follow pins the bottom while content grows', Math.round(offset()), 200 - 
 await wait(300);
 check('scroll={false} clips instead', column().style!.overflowY, 'hidden');
 check('and draws no thumb', Math.round(bounds(thumb())![3]), 0);
+
+// --- virtual: a native <virtual-list> builds only rows near the viewport -------
+({ native } = mount_headless(Tall, { props: { virtual: true, rows: 200 }, width: 400, height: 300 }));
+await wait(300);
+check('a virtual list keeps every row in the tree', all_text().filter((t) => t.startsWith('row ')).length, 200);
+check('but paints only the rows near the viewport', painted().includes('row 0') && !painted().includes('row 150'), true);
+// The list host itself has no tracked bounds; its wrapper and the anchor it reports do.
+const [vx, vy, vw] = bounds(find((n) => n.children?.some((c) => c.type === 'virtual-list') ?? false)!)!;
+const vh = native.getListScrollTop(column().id)![2];
+const v0 = bounds(thumb())!;
+check('the thumb is drawn from the row count', v0[3] > 0 && v0[3] < vh, true);
+native.simulateScrollWheel(vx + vw / 2, vy + vh / 2, 0, -400);
+drain();
+await wait(120);
+check('a wheel scrolls the list', native.getListScrollTop(column().id)![0] > 0, true);
+const v1 = bounds(thumb())!;
+check('and the thumb moves down', v1[1] > v0[1], true);
+native.simulateMouseDown(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2);
+drain();
+settle();
+const before_index = native.getListScrollTop(column().id)![0];
+native.simulateMouseMove(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2 + 60, 0);
+drain();
+settle();
+check('dragging the thumb scrolls by row', native.getListScrollTop(column().id)![0] > before_index, true);
+native.simulateMouseUp(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2 + 60);
+drain();
+settle();
+check('and the rows it left are no longer painted', painted().includes('row 0'), false);
 
 finish('scroller');

--- a/test/scroller.ts
+++ b/test/scroller.ts
@@ -71,15 +71,26 @@ await wait(120);
 check('a wheel scrolls the list', native.getListScrollTop(column().id)![0] > 0, true);
 const v1 = bounds(thumb())!;
 check('and the thumb moves down', v1[1] > v0[1], true);
-native.simulateMouseDown(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2);
+// Rows alternate 30/90 px, so GPUI reports 3 to 5 rows in view as the list moves; the
+// thumb's length must not follow that report around (it swung by 40% before).
+const lengths: number[] = [];
+for (let i = 0; i < 12; i++) {
+	native.simulateScrollWheel(vx + vw / 2, vy + vh / 2, 0, -(15 + (i % 4) * 10));
+	drain();
+	await wait(60);
+	lengths.push(bounds(thumb())![3]);
+}
+check('the thumb keeps its length while the rows in view vary', Math.max(...lengths) - Math.min(...lengths) <= 5, true);
+const v1b = bounds(thumb())!;
+native.simulateMouseDown(v1b[0] + v1b[2] / 2, v1b[1] + v1b[3] / 2);
 drain();
 settle();
 const before_index = native.getListScrollTop(column().id)![0];
-native.simulateMouseMove(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2 + 60, 0);
+native.simulateMouseMove(v1b[0] + v1b[2] / 2, v1b[1] + v1b[3] / 2 + 60, 0);
 drain();
 settle();
 check('dragging the thumb scrolls by row', native.getListScrollTop(column().id)![0] > before_index, true);
-native.simulateMouseUp(v1[0] + v1[2] / 2, v1[1] + v1[3] / 2 + 60);
+native.simulateMouseUp(v1b[0] + v1b[2] / 2, v1b[1] + v1b[3] / 2 + 60);
 drain();
 settle();
 check('and the rows it left are no longer painted', painted().includes('row 0'), false);


### PR DESCRIPTION
Stacked on #9.

## Why
Scrolling Substrate's Everything view lagged. Profiling headlessly: the JavaScript side was free (0.06 ms and one mutation per wheel event), but GPUI laid out and painted all 50 cards every frame, on screen or not: 768 native elements, ~24 ms per frame, versus ~6 ms on Settings. Each wheel event then cost two such frames, GPUI's own redraw plus the Scroller's thumb restyle 16 ms later.

## What
- **`Scroller virtual`** renders GPUI's native `<virtual-list>` instead of an `overflow: scroll` column. Every direct child is a row and only rows near the viewport are built. `estimate` is the height hint for unmeasured rows; `follow` maps to `followTail`. The thumb works in rows via `getListScrollTop` and the `visibleRange` event, and dragging scrolls with `scrollToItem`. The list host has no tracked bounds, so `pad` moves to a wrapper and rows want `width: 100%`.
- **Throttled thumb restyle**: one per 50 ms during a wheel stream, in both modes, since each restyle is a full native frame.
- `visibleRange` added to `GPUI_EVENTS`.
- Substrate's Everything and kind lists use it; the image grid stays a single row.

## Measured (headless, 67 items, 1100×538)
| | before | after |
|---|---|---|
| idle paint, Everything | 23–24 ms | 1.4 ms |
| per wheel event incl. paint | ~48 ms | ~5 ms |
| mutations for 30 wheel events | 30 | 12 |
| cards painted | 50 | 3 |

## Test plan
- [x] `npm test` and `npm run bun:test` green (typecheck, 14 suites, Substrate brain + smoke)
- [x] `test:scroller` gains a virtual section: 200 rows retained vs ~5 painted, wheel, thumb, drag by row
- [x] Substrate screenshots of Everything and Notes in stub mode match the previous layout