### PR TITLE
ESLint with the recommended presets, no rule overrides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           node-version: 26
       - run: npm ci
       - run: npm run typecheck
+      - run: npm run lint
       - run: node -e "const n = require('@gpuix/native'); if (typeof n.GpuixRenderer !== 'function') { console.error('GpuixRenderer missing from the linux prebuild'); process.exit(1) } console.log('binding ok')"
 
   # Build-only: a runner has no display. It checks that the bundle resolves with the

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,17 +8,6 @@ export default ts.config(
 	...ts.configs.recommended,
 	...svelte.configs.recommended,
 	{ files: ['**/*.svelte', '**/*.svelte.ts'], languageOptions: { parserOptions: { parser: ts.parser } } },
-	{
-		languageOptions: { globals: { ...globals.node, Bun: 'readonly' } },
-		rules: {
-			'@typescript-eslint/no-explicit-any': 'off',
-			'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
-			'no-empty': ['error', { allowEmptyCatch: true }],
-			'no-irregular-whitespace': ['error', { skipRegExps: true }],
-			'no-useless-assignment': 'off',
-			'svelte/require-each-key': 'off',
-			'svelte/prefer-svelte-reactivity': 'off'
-		}
-	},
+	{ languageOptions: { globals: { ...globals.node, Bun: 'readonly' } } },
 	{ ignores: ['**/node_modules', 'dist', 'vendor', 'test/.samples-tmp', 'examples/second-brain/.data'] }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import js from '@eslint/js';
+import ts from 'typescript-eslint';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+
+export default ts.config(
+	js.configs.recommended,
+	...ts.configs.recommended,
+	...svelte.configs.recommended,
+	{ files: ['**/*.svelte', '**/*.svelte.ts'], languageOptions: { parserOptions: { parser: ts.parser } } },
+	{
+		languageOptions: { globals: { ...globals.node, Bun: 'readonly' } },
+		rules: {
+			'@typescript-eslint/no-explicit-any': 'off',
+			'@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+			'no-empty': ['error', { allowEmptyCatch: true }],
+			'no-irregular-whitespace': ['error', { skipRegExps: true }],
+			'no-useless-assignment': 'off',
+			'svelte/require-each-key': 'off',
+			'svelte/prefer-svelte-reactivity': 'off'
+		}
+	},
+	{ ignores: ['**/node_modules', 'dist', 'vendor', 'test/.samples-tmp', 'examples/second-brain/.data'] }
+);

--- a/examples/liquid-glass/LiquidGlass.svelte
+++ b/examples/liquid-glass/LiquidGlass.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { GpuixEvent } from 'gpuix-svelte';
+	import { get_native, type GpuixEvent } from 'gpuix-svelte';
 
 	let {
 		glass = false,
@@ -33,12 +33,10 @@
 
 	// GPUI captures no pointer for us, so a drag is: mousedown on the track,
 	// then mousemove/mouseup handled by the surfaces above it (track, card, root).
-	const HOST = Symbol.for('gpuix.svelte.host');
 	let drag = $state<{ key: 'brightness' | 'volume'; trackId: number } | null>(null);
 
 	function slide(e: GpuixEvent) {
-		const native = (globalThis as Record<symbol, any>)[HOST]?.native;
-		const bounds: number[] | null = native?.getElementBounds(drag!.trackId);
+		const bounds = get_native()?.getElementBounds(drag!.trackId);
 		if (!bounds) return;
 		const value = Math.min(1, Math.max(0, (e.x! - bounds[0]) / bounds[2]));
 		if (drag!.key === 'brightness') brightness = value;

--- a/examples/second-brain/RouteView.svelte
+++ b/examples/second-brain/RouteView.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-	import type { Component } from 'svelte';
+	import type { AnyComponent } from 'gpuix-svelte';
 	import { resolve, route, type RouteEntry } from './lib/router.svelte.ts';
 	import { ui } from './lib/ui.svelte.ts';
 
 	let { routes }: { routes: RouteEntry[] } = $props();
 
-	// Component-local, so a hot remount imports the busted specifiers afresh.
-	type Page = Component<any, any, any>;
-	const loaded = new Map<RouteEntry, Page | Promise<Page>>();
+	// Component-local, so a hot remount imports the busted specifiers afresh; not reactive, since `page` writes to it.
+	// eslint-disable-next-line svelte/prefer-svelte-reactivity
+	const loaded = new Map<RouteEntry, AnyComponent | Promise<AnyComponent>>();
 	const match = $derived(resolve(routes, route.path));
 
 	$effect(() => {

--- a/examples/second-brain/components/ItemCard.svelte
+++ b/examples/second-brain/components/ItemCard.svelte
@@ -66,7 +66,7 @@
 			{:else if failed}
 				<div class="error">{item.error ?? 'failed'}</div>
 			{/if}
-			{#each signals ?? [] as signal}
+			{#each signals ?? [] as signal (signal)}
 				<div class="signal {signal}">
 					{#if signal === 'clip'}<Icon name="sparkles" size={11} tone="image" />{/if}
 					<div class="signal-text">{SIGNAL[signal] ?? signal}</div>

--- a/examples/second-brain/lib/ask.ts
+++ b/examples/second-brain/lib/ask.ts
@@ -67,5 +67,5 @@ export async function ask(
 
 	const answer = await create_llm(config).chat(messages, { stream: true, signal, onDelta: on_token });
 	const cited = [...new Set([...answer.matchAll(/\[(\d+)\]/g)].map((m) => Number(m[1])).filter((n) => n >= 1 && n <= sources.length))];
-	return { answer, sources: sources.map(({ text, ...rest }) => rest), cited };
+	return { answer, sources: sources.map(({ text: _text, ...rest }) => rest), cited };
 }

--- a/examples/second-brain/lib/ask.ts
+++ b/examples/second-brain/lib/ask.ts
@@ -38,12 +38,14 @@ export async function ask(
 	const config = settings.llm_config();
 	if (!config) throw new LlmError('no LLM configured — set a base URL and model in Settings', { code: 'NOT_CONFIGURED' });
 
-	const sources: Array<Source & { text: string }> = [];
+	const sources: Source[] = [];
+	const texts: string[] = [];
 	let used = 0;
 	for (const hit of await search.search_chunks(question, { k })) {
 		const text = hit.chunk.text;
 		if (sources.length && used + text.length > max_chars) break;
 		used += text.length;
+		texts.push(text);
 		sources.push({
 			n: sources.length + 1,
 			item_id: hit.item.id,
@@ -51,13 +53,12 @@ export async function ask(
 			title: hit.item.title || 'Untitled',
 			kind: hit.item.kind,
 			snippet: clip_snippet(text, 160),
-			date: new Date(hit.item.created_at).toISOString().slice(0, 10),
-			text
+			date: new Date(hit.item.created_at).toISOString().slice(0, 10)
 		});
 	}
 
 	const context = sources.length
-		? `Sources:\n\n${sources.map((s) => `[${s.n}] ${s.title} (${s.kind}, ${s.date})\n${s.text}`).join('\n\n')}`
+		? `Sources:\n\n${sources.map((s, i) => `[${s.n}] ${s.title} (${s.kind}, ${s.date})\n${texts[i]}`).join('\n\n')}`
 		: 'Sources: nothing in the brain matched this question.';
 	const messages: Message[] = [
 		{ role: 'system', content: SYSTEM },
@@ -67,5 +68,5 @@ export async function ask(
 
 	const answer = await create_llm(config).chat(messages, { stream: true, signal, onDelta: on_token });
 	const cited = [...new Set([...answer.matchAll(/\[(\d+)\]/g)].map((m) => Number(m[1])).filter((n) => n >= 1 && n <= sources.length))];
-	return { answer, sources: sources.map(({ text: _text, ...rest }) => rest), cited };
+	return { answer, sources, cited };
 }

--- a/examples/second-brain/lib/capture.svelte.ts
+++ b/examples/second-brain/lib/capture.svelte.ts
@@ -3,7 +3,7 @@
  * the chooser or the clipboard, recordings, playback.
  */
 
-import { unlinkSync } from 'node:fs';
+import { rmSync } from 'node:fs';
 import { data, get_app } from './data.svelte.ts';
 import { choose_files } from './dialogs.ts';
 import { warn } from './log.ts';
@@ -128,9 +128,7 @@ export async function stop_recording() {
 	const seconds = await rec.stop();
 	if (seconds < 0.5) {
 		toast('Recording too short', 'error');
-		try {
-			unlinkSync(recording.path);
-		} catch {}
+		rmSync(recording.path, { force: true });
 		return;
 	}
 	await get_app().add_audio(recording.path, { move: true });

--- a/examples/second-brain/lib/data.svelte.ts
+++ b/examples/second-brain/lib/data.svelte.ts
@@ -145,7 +145,7 @@ export function ago(ts: number): string {
 	if (mins < 60) return `${mins}m ago`;
 	if (mins < 60 * 24) return `${Math.round(mins / 60)}h ago`;
 	if (mins < 60 * 24 * 30) return `${Math.round(mins / (60 * 24))}d ago`;
-	return new Date(ts).toLocaleDateString();
+	return new Intl.DateTimeFormat().format(ts);
 }
 
 export const display_title = (item: Item): string => item.title || (item.kind === 'link' ? item.source_url : '') || 'Untitled';

--- a/examples/second-brain/lib/ingest.ts
+++ b/examples/second-brain/lib/ingest.ts
@@ -49,7 +49,7 @@ export function create_ingestor({ store, vectors, images, ml, media, settings, b
 	const queue: number[] = [];
 	const active = new Set<number>();
 	const timers = new Map<number, ReturnType<typeof setTimeout>>();
-	let waiters: Array<() => void> = [];
+	const waiters: Array<() => void> = [];
 	let done = 0;
 	let failed = 0;
 

--- a/examples/second-brain/lib/ingest.ts
+++ b/examples/second-brain/lib/ingest.ts
@@ -162,7 +162,7 @@ export function create_ingestor({ store, vectors, images, ml, media, settings, b
 
 	async function transcribe_step(item: Item) {
 		const language = settings.get('stt.language') || null;
-		const result = await ml.transcribe(item.meta.pcm_path, {
+		const result = await ml.transcribe(item.meta.pcm_path!, {
 			language,
 			on_progress: (p) =>
 				emit_item(item.id, {

--- a/examples/second-brain/lib/lifecycle.ts
+++ b/examples/second-brain/lib/lifecycle.ts
@@ -32,12 +32,16 @@ export function install_exit_handlers() {
 		for (const fn of hooks) {
 			try {
 				fn();
-			} catch {}
+			} catch {
+				// One hook failing must not skip the rest at exit.
+			}
 		}
 		for (const proc of children) {
 			try {
 				proc.kill();
-			} catch {}
+			} catch {
+				// Already gone.
+			}
 		}
 	});
 

--- a/examples/second-brain/lib/llm.ts
+++ b/examples/second-brain/lib/llm.ts
@@ -113,7 +113,7 @@ function host_of(url: string): string {
 
 export function friendly_http_error(status: number, body: string, { url, baseUrl, model }: { url: string; baseUrl: string; model: string }): LlmError {
 	const host = host_of(url);
-	let detail = '';
+	let detail: string;
 	try {
 		detail = JSON.parse(body)?.error?.message ?? '';
 	} catch {
@@ -167,6 +167,11 @@ export function create_llm(config: LlmConfig) {
 		return res;
 	};
 
+	interface ChatResponse {
+		error?: { message?: string };
+		choices?: Array<{ message?: { content?: string }; delta?: { content?: string } }>;
+	}
+
 	async function chat(messages: Message[], { stream = true, signal, onDelta, temperature = 0.2, maxTokens }: ChatOptions = {}): Promise<string> {
 		const body: Record<string, unknown> = { model: config.model, messages, stream, temperature };
 		if (maxTokens) body.max_tokens = maxTokens;
@@ -174,7 +179,7 @@ export function create_llm(config: LlmConfig) {
 
 		const type = (res.headers.get('content-type') ?? '').toLowerCase();
 		if (!stream || type.includes('application/json')) {
-			const json: any = await res.json();
+			const json = (await res.json()) as ChatResponse;
 			if (json.error) throw new LlmError(json.error.message ?? String(json.error));
 			const text = json.choices?.[0]?.message?.content ?? '';
 			onDelta?.(text, text);
@@ -184,7 +189,7 @@ export function create_llm(config: LlmConfig) {
 		let full = '';
 		for await (const payload of parse_sse(res.body!)) {
 			if (payload === '[DONE]') break;
-			let obj;
+			let obj: ChatResponse;
 			try {
 				obj = JSON.parse(payload);
 			} catch {
@@ -201,9 +206,9 @@ export function create_llm(config: LlmConfig) {
 
 	async function models(): Promise<string[]> {
 		const res = await request('/models', { method: 'GET' });
-		const json: any = await res.json();
-		const list: any[] = Array.isArray(json.data) ? json.data : Array.isArray(json.models) ? json.models : [];
-		return list.map((m) => m.id ?? m.name).filter(Boolean).sort();
+		const json = (await res.json()) as { data?: unknown; models?: unknown };
+		const list = (Array.isArray(json.data) ? json.data : Array.isArray(json.models) ? json.models : []) as Array<{ id?: string; name?: string }>;
+		return list.map((m) => m.id ?? m.name ?? '').filter(Boolean).sort();
 	}
 
 	async function test() {

--- a/examples/second-brain/lib/media.ts
+++ b/examples/second-brain/lib/media.ts
@@ -98,7 +98,7 @@ export function create_media(dirs: DataDirs) {
 		/** `file` is the stored original. */
 		async prepare_pcm(file: string, id: number): Promise<{ pcm_path: string; duration: number; converted: boolean }> {
 			const extension = extname(file).slice(1).toLowerCase();
-			let pcm_path = file;
+			let pcm_path: string;
 			if (extension === 'wav' && (await wav_is_pcm16_mono_16k(file)).ok) {
 				pcm_path = file;
 			} else if (extension === 'wav') {

--- a/examples/second-brain/lib/ml-client.ts
+++ b/examples/second-brain/lib/ml-client.ts
@@ -409,7 +409,9 @@ export class MlClient implements MlLike {
 		if (!proc) return;
 		try {
 			proc.send({ type: 'shutdown' });
-		} catch {}
+		} catch {
+			// The channel closes with the worker; the kill below covers it.
+		}
 		setTimeout(() => proc.kill(), 500);
 		await proc.exited;
 		this.status.worker = 'down';

--- a/examples/second-brain/lib/router.svelte.ts
+++ b/examples/second-brain/lib/router.svelte.ts
@@ -4,7 +4,7 @@
  * hot remount.
  */
 
-import type { Component } from 'svelte';
+import type { AnyComponent } from 'gpuix-svelte';
 
 /** The current location. */
 export interface Route {
@@ -16,7 +16,7 @@ export interface Route {
 /** One entry of the route table `RouteView` resolves against. */
 export interface RouteEntry {
 	path: string;
-	load: () => Promise<{ default: Component<any, any, any> }>;
+	load: () => Promise<{ default: AnyComponent }>;
 	props?: Record<string, unknown>;
 	title: string;
 }

--- a/examples/second-brain/lib/scrape.ts
+++ b/examples/second-brain/lib/scrape.ts
@@ -71,7 +71,7 @@ export function decode_entities(s: string): string {
 const tidy = (s: string) =>
 	s
 		.replace(/\r/g, '')
-		.replace(/[ \t\f\v ]+/g, ' ')
+		.replace(/[ \t\f\v\u00a0]+/g, ' ')
 		.replace(/ *\n */g, '\n')
 		// Table rows: empty cells collapse, and a row that was only cells goes away.
 		.replace(/(?: ?\|){2,}/g, ' |')
@@ -250,10 +250,7 @@ export function extract(html: string, { baseUrl = 'http://localhost/', maxChars 
 	const text = truncate(tidy((winner ? out.slice(winner.start, winner.end) : out).join('')), maxChars);
 
 	const base = resolve(meta.base, baseUrl) ?? baseUrl;
-	let hostname = '';
-	try {
-		hostname = new URL(baseUrl).hostname.replace(/^www\./, '');
-	} catch {}
+	const hostname = URL.parse(baseUrl)?.hostname.replace(/^www\./, '') ?? '';
 
 	const siteName = decode_entities(meta.og.site_name || hostname);
 	const headline = headings
@@ -318,10 +315,7 @@ export function looks_like_url(text: string): boolean {
 }
 
 export function friendly_fetch_error(err: unknown, url: string): Failure {
-	let host = url;
-	try {
-		host = new URL(url).host;
-	} catch {}
+	const host = URL.parse(url)?.host ?? url;
 	const message = String((err as Failure)?.message ?? err);
 	const name = (err as Failure)?.name ?? '';
 	let friendly: string;
@@ -416,10 +410,12 @@ export async function scrape(
 		return { ...empty_page(finalUrl), text: truncate(tidy(body), maxChars), url: finalUrl, contentType: type, truncated };
 	}
 	if (type === 'application/json') {
-		let text = body;
+		let text: string;
 		try {
 			text = JSON.stringify(JSON.parse(body), null, 2);
-		} catch {}
+		} catch {
+			text = body;
+		}
 		return { ...empty_page(finalUrl), text: '```\n' + truncate(text, maxChars) + '\n```', url: finalUrl, contentType: type, truncated };
 	}
 	if (type && type !== 'text/html' && type !== 'application/xhtml+xml') {
@@ -431,10 +427,7 @@ export async function scrape(
 }
 
 function empty_page(url: string): PageData {
-	let hostname = '';
-	try {
-		hostname = new URL(url).hostname.replace(/^www\./, '');
-	} catch {}
+	const hostname = URL.parse(url)?.hostname.replace(/^www\./, '') ?? '';
 	return { title: '', siteName: hostname, description: '', imageUrl: null, canonical: url, lang: '', text: '', candidates: [] };
 }
 

--- a/examples/second-brain/lib/search.ts
+++ b/examples/second-brain/lib/search.ts
@@ -109,7 +109,9 @@ export function create_search({ store, vectors, images, ml }: { store: Store; ve
 			try {
 				const item = store.get_item_by_url(normalize_url(q));
 				if (item) rankings.url = [{ id: item.id, score: 1 }];
-			} catch {}
+			} catch {
+				// Looked like a URL but did not parse as one; the other rankings still apply.
+			}
 		}
 
 		if (signals.includes('clip') && (!kinds || kinds.includes('image')) && images.size > 0) {

--- a/examples/second-brain/lib/store.ts
+++ b/examples/second-brain/lib/store.ts
@@ -1,5 +1,34 @@
 import type { Database } from 'bun:sqlite';
+import type { TranscribeSegment } from './ml-client.ts';
 import { to_blob } from './vectors.ts';
+
+/** The JSON `meta` column; every key is optional because each pipeline step adds its own. */
+export interface ItemMeta {
+	auto_title?: boolean;
+	original_name?: string;
+	format?: string | null;
+	thumb_width?: number;
+	thumb_height?: number;
+	display_path?: string | null;
+	described_by?: string;
+	describe_error?: string | null;
+	summary?: string;
+	summarized_by?: string;
+	site_name?: string;
+	canonical_url?: string | null;
+	excerpt?: string;
+	lang?: string;
+	og_image?: string | null;
+	final_url?: string;
+	fetched_at?: number;
+	truncated?: boolean;
+	empty?: boolean;
+	pcm_path?: string;
+	segments?: TranscribeSegment[];
+	language?: string | null;
+	embed_model?: string;
+	embedded_at?: number;
+}
 
 export type Kind = 'text' | 'link' | 'image' | 'audio';
 export type Status = 'pending' | 'processing' | 'ready' | 'error';
@@ -18,7 +47,7 @@ export type Item = {
 	status: Status;
 	error: string | null;
 	attempts: number;
-	meta: Record<string, any>;
+	meta: ItemMeta;
 	created_at: number;
 	updated_at: number;
 };
@@ -64,7 +93,7 @@ const ITEM_COLS =
 	'id, kind, title, body, source_url, file_path, thumb_path, width, height, duration, status, error, attempts, meta, created_at, updated_at';
 const PATCHABLE = new Set(['kind', 'title', 'body', 'source_url', 'file_path', 'thumb_path', 'width', 'height', 'duration', 'status', 'error', 'attempts']);
 
-const parse_meta = (s: string): Record<string, any> => {
+const parse_meta = (s: string): ItemMeta => {
 	try {
 		return JSON.parse(s) ?? {};
 	} catch {
@@ -187,7 +216,7 @@ export function create_store(db: Database) {
 		unfinished_items: (): Item[] => unfinished_stmt.all().map(to_item) as Item[],
 		errored_items: (): Item[] => errored_stmt.all().map(to_item) as Item[],
 
-		delete_item: db.transaction((id: number): { chunk_ids: number[]; file_path: string | null; thumb_path: string | null; meta: Record<string, any> } | null => {
+		delete_item: db.transaction((id: number): { chunk_ids: number[]; file_path: string | null; thumb_path: string | null; meta: ItemMeta } | null => {
 			const item = store.get_item(id);
 			if (!item) return null;
 			const chunk_ids = chunk_ids_stmt.all({ item_id: id }).map((r) => r.id);
@@ -265,7 +294,9 @@ export function create_store(db: Database) {
 			for (const row of settings_all_stmt.all()) {
 				try {
 					out[row.key] = JSON.parse(row.value);
-				} catch {}
+				} catch {
+					// A row an older build wrote by hand; skipping it beats failing every setting.
+				}
 			}
 			return out;
 		},

--- a/examples/second-brain/ml/worker.ts
+++ b/examples/second-brain/ml/worker.ts
@@ -7,7 +7,18 @@ import type { ModelName, ModelState, WorkerHandlers, WorkerJob, WorkerMessage, W
 import type { Failure } from '../lib/types.ts';
 import { decode_wav } from '../lib/wav.ts';
 
-type Loaded = Record<string, any>;
+type Tf = typeof import('@huggingface/transformers');
+interface LoadedOf {
+	embed: { extractor: Tf['FeatureExtractionPipeline']['prototype'] };
+	whisper: { asr: Tf['AutomaticSpeechRecognitionPipeline']['prototype'] };
+	clip: {
+		processor: Tf['Processor']['prototype'];
+		vision: Tf['CLIPVisionModelWithProjection']['prototype'];
+		tokenizer: Tf['PreTrainedTokenizer']['prototype'];
+		text: Tf['CLIPTextModelWithProjection']['prototype'];
+	};
+}
+type Loaded = LoadedOf[ModelName];
 interface TfProgress {
 	status: string;
 	file?: string;
@@ -43,7 +54,7 @@ const device = process.env.GPUIX_BRAIN_ML === 'wasm' ? 'wasm' : undefined;
 if (device === 'wasm' && env.backends?.onnx?.wasm) env.backends.onnx.wasm.numThreads = 1;
 const threads = Math.max(1, Math.min(4, Math.floor((navigator.hardwareConcurrency || 4) / 2)));
 
-const loaded: Partial<Record<ModelName, Loaded>> = {};
+const loaded: Partial<LoadedOf> = {};
 const loading: Partial<Record<ModelName, Promise<Loaded> | null>> = {};
 const last_used: Partial<Record<ModelName, number>> = {};
 const IDLE_UNLOAD_MS = 15 * 60_000;
@@ -66,6 +77,7 @@ function progress_for(model: ModelName) {
 	};
 }
 
+async function load<M extends ModelName>(model: M): Promise<LoadedOf[M]>;
 async function load(model: ModelName): Promise<Loaded> {
 	const progress_callback = progress_for(model);
 	// No memory arena: ORT would otherwise keep the largest batch's working set forever.
@@ -84,14 +96,15 @@ async function load(model: ModelName): Promise<Loaded> {
 	throw new Error(`unknown model ${model}`);
 }
 
-function ensure(model: ModelName): Promise<Loaded> {
+function ensure<M extends ModelName>(model: M): Promise<LoadedOf[M]> {
 	last_used[model] = Date.now();
-	if (loaded[model]) return Promise.resolve(loaded[model]);
+	const ready = loaded[model];
+	if (ready) return Promise.resolve(ready);
 	if (!loading[model]) {
 		status(model, 'loading');
 		loading[model] = load(model).then(
 			(m) => {
-				loaded[model] = m;
+				(loaded as Record<ModelName, Loaded>)[model] = m;
 				status(model, 'ready', { progress: 100 });
 				return m;
 			},
@@ -102,7 +115,7 @@ function ensure(model: ModelName): Promise<Loaded> {
 			}
 		);
 	}
-	return loading[model];
+	return loading[model] as Promise<LoadedOf[M]>;
 }
 
 const unit = (data: ArrayLike<number>) => {

--- a/examples/second-brain/test/smoke.ts
+++ b/examples/second-brain/test/smoke.ts
@@ -44,7 +44,7 @@ await app.ingest.idle();
 
 const App = (await import('../App.svelte')).default;
 // 538 is the headless height cap; anything laid out below it cannot be hit.
-const { native } = mount_headless(App, { props: { app }, width: 1100, height: 538 });
+mount_headless(App, { props: { app }, width: 1100, height: 538 });
 
 /** A click, then the timers and dynamic imports a route change runs through. */
 async function tap(text: string, opts?: ClickOptions) {

--- a/examples/styling-playground/StylingPlayground.svelte
+++ b/examples/styling-playground/StylingPlayground.svelte
@@ -149,13 +149,13 @@
 </script>
 
 <div style="display: flex; flex-direction: row; gap: 16px; width: 100%; height: 100%; background-color: #11111b; padding: 16px">
-	{#each SECTIONS as section}
+	{#each SECTIONS as section (section.title)}
 		<Scroller gap={8}>
 			<div style="font-size: 14px; font-weight: bold" style:color={section.color}>
 				{section.title}
 			</div>
 
-			{#each section.cases as c}
+			{#each section.cases as c (c)}
 				<div
 					style="display: flex; flex-direction: column; gap: 6px; padding: 10px;
 					       background-color: #1e1e2e; border-radius: 8px"
@@ -173,7 +173,7 @@
 							active={c.active}
 						>
 							{#if c.kind === 'children'}
-								{#each BLOCKS as color}
+								{#each BLOCKS as color (color)}
 									<div style="width: 28px; height: 20px; border-radius: 3px" style:background-color={color}></div>
 								{/each}
 							{:else if c.kind === 'lines'}

--- a/examples/tic-tac-toe/TicTacToe.svelte
+++ b/examples/tic-tac-toe/TicTacToe.svelte
@@ -70,9 +70,9 @@
 		style="display: flex; flex-direction: column; gap: 8px; padding: 16px;
 		       background-color: #1e1e2e; border-radius: 12px"
 	>
-		{#each [0, 1, 2] as row}
+		{#each [0, 1, 2] as row (row)}
 			<div style="display: flex; flex-direction: row; gap: 8px">
-				{#each [0, 1, 2] as col}
+				{#each [0, 1, 2] as col (col)}
 					{@const i = row * 3 + col}
 					<div
 						style="display: flex; align-items: center; justify-content: center;

--- a/examples/tutorial/Diagram.svelte
+++ b/examples/tutorial/Diagram.svelte
@@ -31,7 +31,7 @@
 			style:flex-wrap={column ? 'nowrap' : 'wrap'}
 			style:align-items={column ? 'flex-start' : 'center'}
 		>
-			{#each spec.nodes as node, i}
+			{#each spec.nodes as node, i (node)}
 				{#if i > 0}
 					<div style="color: #6c7086; font-size: 16px; pointer-events: none" style:padding-left={column ? '14px' : '0px'}>
 						{column ? '↓' : '→'}
@@ -47,12 +47,12 @@
 		</div>
 	{:else if spec.kind === 'compare'}
 		<div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: 16px">
-			{#each [spec.left, spec.right] as side}
+			{#each [spec.left, spec.right] as side (side)}
 				<div style="display: flex; flex-direction: column; gap: 5px; flex-grow: 1; flex-basis: 200px; min-width: 0">
 					<div style="font-size: 12px; font-weight: bold; margin-bottom: 2px" style:color={side.color ?? '#a6adc8'}>
 						{side.title}
 					</div>
-					{#each flatten(side.tree) as row}
+					{#each flatten(side.tree) as row (row)}
 						<div
 							style="display: flex; flex-direction: column; gap: 3px; pointer-events: none"
 							style:padding-left="{row.depth * 16}px"

--- a/examples/tutorial/Quiz.svelte
+++ b/examples/tutorial/Quiz.svelte
@@ -23,7 +23,7 @@
 	<div style="font-size: 11px; font-weight: bold; color: #f9e2af">QUIZ</div>
 	<div style="font-size: 13px; line-height: 19px; color: #cdd6f4">{question}</div>
 
-	{#each options as option, i}
+	{#each options as option, i (option)}
 		<div
 			style="padding: 8px 10px; border-radius: 6px; border-width: 1px; font-size: 13px; line-height: 18px;
 			       user-select: none; {option_style(i)}"

--- a/examples/tutorial/Tutorial.svelte
+++ b/examples/tutorial/Tutorial.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { readFileSync } from 'node:fs';
 	import { spawn } from 'node:child_process';
-	import type { Component } from 'svelte';
-	import { blur, on_window_key, type GpuixEvent } from 'gpuix-svelte';
+	import { blur, on_window_key, type AnyComponent, type GpuixEvent } from 'gpuix-svelte';
 	import { CHAPTERS, STEPS as RAW_STEPS, type LiveKey, type Step } from './steps.ts';
 	import { THEME } from './theme.ts';
 	import Scroller from 'gpuix-svelte/components/Scroller.svelte';
@@ -18,7 +17,7 @@
 	import Native from './samples/Native.svelte';
 	import Motion from './samples/Motion.svelte';
 
-	const LIVE: Record<LiveKey, Component<any, any, any>> = { hello: Hello, counter: Counter, styled: Styled, scroll: Scroll, list: List, hittest: HitTest, native: Native, motion: Motion };
+	const LIVE: Record<LiveKey, AnyComponent> = { hello: Hello, counter: Counter, styled: Styled, scroll: Scroll, list: List, hittest: HitTest, native: Native, motion: Motion };
 
 	// Read here rather than in steps.ts: a hot reload re-evaluates this module but
 	// not plain JS, so a saved sample shows its new source.

--- a/examples/tutorial/samples/Scroll.svelte
+++ b/examples/tutorial/samples/Scroll.svelte
@@ -6,7 +6,7 @@
 	style="display: flex; flex-direction: column; flex-grow: 1; min-height: 0;
 	       gap: 6px; overflow-y: scroll; padding-right: 8px"
 >
-	{#each rows as row}
+	{#each rows as row (row)}
 		<div
 			style="padding: 8px 12px; border-radius: 6px; background-color: #313244;
 			       color: #cdd6f4; font-size: 13px"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,15 @@
 				"gpuix-svelte": "bin/gpuix-svelte.js"
 			},
 			"devDependencies": {
+				"@eslint/js": "^10.0.1",
 				"@types/bun": "^1.4.0",
 				"@types/node": "^26.4.1",
+				"eslint": "^10.9.1",
+				"eslint-plugin-svelte": "^3.23.0",
+				"globals": "^17.12.0",
 				"svelte": "file:vendor/svelte-5.57.0-6be4ab9.tgz",
-				"typescript": "^5.9.3"
+				"typescript": "^5.9.3",
+				"typescript-eslint": "^8.69.0"
 			},
 			"engines": {
 				"bun": ">=1.4.0",
@@ -446,6 +451,134 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils": {
+			"version": "4.10.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+			"integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-visitor-keys": "^3.4.3"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+			}
+		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@eslint-community/regexpp": {
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/@eslint/config-array": {
+			"version": "0.23.5",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+			"integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/object-schema": "^3.0.5",
+				"debug": "^4.3.1",
+				"minimatch": "^10.2.4"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/config-helpers": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+			"integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/core": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+			"integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@types/json-schema": "^7.0.15"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/js": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+			"integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"eslint": "^10.0.0"
+			},
+			"peerDependenciesMeta": {
+				"eslint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@eslint/object-schema": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+			"integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
+		"node_modules/@eslint/plugin-kit": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@eslint/core": "^1.2.1",
+				"levn": "^0.4.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			}
+		},
 		"node_modules/@gpuix/native": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@gpuix/native/-/native-0.7.0.tgz",
@@ -498,6 +631,72 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@humanfs/core": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+			"integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/types": "^0.15.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/node": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+			"integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@humanfs/core": "^0.19.2",
+				"@humanfs/types": "^0.15.0",
+				"@humanwhocodes/retry": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanfs/types": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+			"integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18.0"
+			}
+		},
+		"node_modules/@humanwhocodes/module-importer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12.22"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
+		},
+		"node_modules/@humanwhocodes/retry": {
+			"version": "0.4.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/nzakas"
+			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
@@ -569,10 +768,24 @@
 				"bun-types": "1.4.0"
 			}
 		},
+		"node_modules/@types/esrecurse": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+			"integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
 			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/json-schema": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -586,6 +799,236 @@
 				"undici-types": "~8.3.0"
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
+			"integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/type-utils": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
+				"ignore": "^7.0.5",
+				"natural-compare": "^1.4.0",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/parser": "^8.69.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+			"version": "7.0.8",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.8.tgz",
+			"integrity": "sha512-YYNsSlXBjMk92SKnkwvB5LOVSa6OznlFUGcsvrFgNJbJCd0M1XKeFVRc8ZByeCqz32FivYNHJVooLmdqrmvp/Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
+			"integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/project-service": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
+			"integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/tsconfig-utils": "^8.69.0",
+				"@typescript-eslint/types": "^8.69.0",
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
+			"integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/tsconfig-utils": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
+			"integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/type-utils": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
+			"integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/types": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
+			"integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/typescript-estree": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
+			"integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/project-service": "8.69.0",
+				"@typescript-eslint/tsconfig-utils": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/visitor-keys": "8.69.0",
+				"debug": "^4.4.3",
+				"minimatch": "^10.2.2",
+				"semver": "^7.7.3",
+				"tinyglobby": "^0.2.15",
+				"ts-api-utils": "^2.5.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/utils": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
+			"integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.69.0",
+				"@typescript-eslint/types": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
+			"integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "8.69.0",
+				"eslint-visitor-keys": "^5.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -596,6 +1039,33 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-jsx": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"fast-json-stable-stringify": "^2.0.0",
+				"json-schema-traverse": "^0.4.1",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/aria-query": {
@@ -618,6 +1088,29 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/bun-types": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.4.0.tgz",
@@ -637,6 +1130,59 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/cssesc": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/devalue": {
 			"version": "5.9.2",
@@ -686,12 +1232,194 @@
 				"@esbuild/win32-x64": "0.28.2"
 			}
 		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint": {
+			"version": "10.9.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.9.1.tgz",
+			"integrity": "sha512-9VaAkDURekixUQJy0oJYl2DcN6oKMfxay7XzaGYAWQwsb6qfKf+x76R2k1L8kb1boc+FyCAaTA9GmiKaaiaF+A==",
+			"dev": true,
+			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.8.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@eslint/config-array": "^0.23.5",
+				"@eslint/config-helpers": "^0.7.0",
+				"@eslint/core": "^1.2.1",
+				"@eslint/plugin-kit": "^0.7.2",
+				"@humanfs/node": "^0.16.6",
+				"@humanwhocodes/module-importer": "^1.0.1",
+				"@humanwhocodes/retry": "^0.4.2",
+				"@types/estree": "^1.0.6",
+				"ajv": "^6.14.0",
+				"cross-spawn": "^7.0.6",
+				"debug": "^4.3.2",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^9.1.2",
+				"eslint-visitor-keys": "^5.0.1",
+				"espree": "^11.2.0",
+				"esquery": "^1.7.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^8.0.0",
+				"find-up": "^5.0.0",
+				"glob-parent": "^6.0.2",
+				"ignore": "^5.2.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"minimatch": "^10.2.5",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.3"
+			},
+			"bin": {
+				"eslint": "bin/eslint.js"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://eslint.org/donate"
+			},
+			"peerDependencies": {
+				"jiti": "*"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-svelte": {
+			"version": "3.23.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.23.0.tgz",
+			"integrity": "sha512-n9jRklDqy0+W834568a4ZIZTK7DHXxvvHHxxGP8nNq7N//pOZMubttskHOquyGgfTR4Z05q2NdGNlsTpIEA48w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@eslint-community/eslint-utils": "^4.6.1",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"esutils": "^2.0.3",
+				"globals": "^16.0.0",
+				"known-css-properties": "^0.37.0",
+				"postcss": "^8.4.49",
+				"postcss-load-config": "^3.1.4",
+				"postcss-safe-parser": "^7.0.0",
+				"semver": "^7.6.3",
+				"svelte-eslint-parser": "^1.7.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.1 || ^9.0.0 || ^10.0.0",
+				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"svelte": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-svelte/node_modules/globals": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "9.1.2",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+			"integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"@types/esrecurse": "^4.3.1",
+				"@types/estree": "^1.0.8",
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
 			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/espree": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+			"integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.16.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^5.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.13.0 || >=24"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esquery": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"estraverse": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
 		},
 		"node_modules/esrap": {
 			"version": "2.3.6",
@@ -711,6 +1439,129 @@
 				}
 			}
 		},
+		"node_modules/esrecurse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/fdir": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+			"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"peerDependencies": {
+				"picomatch": "^3 || ^4"
+			},
+			"peerDependenciesMeta": {
+				"picomatch": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/file-entry-cache": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flat-cache": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/flat-cache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"flatted": "^3.2.9",
+				"keyv": "^4.5.4"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/flatted": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+			"integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+			"dev": true,
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -725,6 +1576,75 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/glob-parent": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"is-glob": "^4.0.3"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/globals": {
+			"version": "17.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.12.0.tgz",
+			"integrity": "sha512-cezEd/DTyyht9cvSSURyygXPfy04GtWO/5e6ZPvH7fCtjKz9PYOmuawphw1Ctd1f6C+5JypXfGD7ahNMXvevBA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/is-extglob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-glob": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extglob": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -735,12 +1655,97 @@
 				"@types/estree": "^1.0.6"
 			}
 		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/json-buffer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify-without-jsonify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/keyv": {
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/known-css-properties": {
+			"version": "0.37.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/levn": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lilconfig": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+			"integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
@@ -750,6 +1755,338 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.8"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/nanoid": {
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/natural-compare": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+			"integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/optionator": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/picocolors": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/picomatch": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+			"integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/postcss": {
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"nanoid": "^3.3.17",
+				"picocolors": "^1.1.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/postcss-load-config": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+			"integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lilconfig": "^2.0.5",
+				"yaml": "^1.10.2"
+			},
+			"engines": {
+				"node": ">= 10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/postcss/"
+			},
+			"peerDependencies": {
+				"postcss": ">=8.0.9",
+				"ts-node": ">=9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"postcss": {
+					"optional": true
+				},
+				"ts-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/postcss-safe-parser": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+			"integrity": "sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-safe-parser"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-scss": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+			"integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/postcss-scss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4.29"
+			}
+		},
+		"node_modules/postcss-selector-parser": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+			"integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/svelte": {
@@ -779,6 +2116,115 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/svelte-eslint-parser": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.1.tgz",
+			"integrity": "sha512-5zgKBqAf6V8Jyrmr1jViksyG4NKT8NheYwkdxRaMRDAqpGWi9wR8ktcGrAZbfMn/PHUp1BWzAp0cYQECkWuAMA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"eslint-scope": "^8.2.0",
+				"eslint-visitor-keys": "^4.0.0",
+				"espree": "^10.0.0",
+				"postcss": "^8.4.49",
+				"postcss-scss": "^4.0.9",
+				"postcss-selector-parser": "^7.0.0",
+				"semver": "^7.7.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0",
+				"pnpm": "10.34.5"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ota-meshi"
+			},
+			"peerDependencies": {
+				"svelte": "^3.37.0 || ^4.0.0 || ^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"svelte": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/svelte-eslint-parser/node_modules/eslint-scope": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esrecurse": "^4.3.0",
+				"estraverse": "^5.2.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/svelte-eslint-parser/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/svelte-eslint-parser/node_modules/espree": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"acorn": "^8.15.0",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/tinyglobby": {
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fdir": "^6.5.0",
+				"picomatch": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/SuperchupuDev"
+			}
+		},
+		"node_modules/ts-api-utils": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+			"integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.8.4"
+			}
+		},
 		"node_modules/tsx": {
 			"version": "4.23.13",
 			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
@@ -797,6 +2243,19 @@
 				"fsevents": "~2.3.3"
 			}
 		},
+		"node_modules/type-check": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"prelude-ls": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -811,12 +2270,102 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/typescript-eslint": {
+			"version": "8.69.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
+			"integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/eslint-plugin": "8.69.0",
+				"@typescript-eslint/parser": "8.69.0",
+				"@typescript-eslint/typescript-estree": "8.69.0",
+				"@typescript-eslint/utils": "8.69.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+				"typescript": ">=4.8.4 <6.1.0"
+			}
+		},
 		"node_modules/undici-types": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/zimmerframe": {
 			"version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 	],
 	"scripts": {
 		"typecheck": "tsc --noEmit",
+		"lint": "eslint .",
 		"demo": "node --import tsx scripts/demo-all.ts",
 		"demo:counter": "node bin/gpuix-svelte.js examples/counter/main.ts",
 		"demo:tictactoe": "node bin/gpuix-svelte.js examples/tic-tac-toe/main.ts",
@@ -111,10 +112,15 @@
 		"svelte": ">=5.56.0"
 	},
 	"devDependencies": {
+		"@eslint/js": "^10.0.1",
 		"@types/bun": "^1.4.0",
 		"@types/node": "^26.4.1",
+		"eslint": "^10.9.1",
+		"eslint-plugin-svelte": "^3.23.0",
+		"globals": "^17.12.0",
 		"svelte": "file:vendor/svelte-5.57.0-6be4ab9.tgz",
-		"typescript": "^5.9.3"
+		"typescript": "^5.9.3",
+		"typescript-eslint": "^8.69.0"
 	},
 	"publishConfig": {
 		"registry": "https://registry.npmjs.org/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,5 +28,6 @@ export type {
 	NativeSink,
 	Native,
 	RenderOptions,
-	WindowKeyType
+	WindowKeyType,
+	AnyComponent
 } from './types.ts';

--- a/src/render.ts
+++ b/src/render.ts
@@ -8,7 +8,7 @@ import { watch } from 'node:fs';
 import { dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { GpuixRenderer, type EventPayload } from '@gpuix/native';
-import { mount, unmount, flushSync, type Component } from 'svelte';
+import { mount, unmount, flushSync } from 'svelte';
 import renderer, {
 	set_native,
 	create_root,
@@ -19,7 +19,7 @@ import renderer, {
 	queue_destroy,
 	on_window_key
 } from './renderer.ts';
-import type { RenderOptions, ShadowNode } from './types.ts';
+import type { AnyComponent, RenderOptions, ShadowNode } from './types.ts';
 
 /**
  * ~125fps, above any common refresh rate. `setImmediate` instead of a paced
@@ -32,7 +32,7 @@ const SLOT = Symbol.for('gpuix.svelte.host');
 interface Host {
 	native: GpuixRenderer | null;
 	root: ShadowNode | null;
-	component: Record<string, any> | null;
+	component: Record<string, unknown> | null;
 	loop: { stop(): void } | null;
 	keys: Array<() => void>;
 }
@@ -105,7 +105,7 @@ export function start_frame_loop(native: Pick<GpuixRenderer, 'requiresTick' | 't
 }
 
 /** Mounts a compiled `.svelte` component into the window, creating it on the first call. */
-export function render(Component: Component<any, any, any>, options: RenderOptions = {}): Record<string, any> {
+export function render(Component: AnyComponent, options: RenderOptions = {}): Record<string, unknown> {
 	const { props = {}, rootStyle, onEvent, onKeyDown, onKeyUp, ...window_options } = options;
 	const slot = host();
 	const remount = slot.component != null;

--- a/src/test.ts
+++ b/src/test.ts
@@ -36,7 +36,7 @@ export interface ClickOptions extends FindOptions {
 }
 
 export interface MountHeadlessOptions {
-	props?: Record<string, any>;
+	props?: Record<string, unknown>;
 	width?: number;
 	height?: number;
 	rootStyle?: GpuiStyle;
@@ -48,7 +48,8 @@ function native(): TestGpuixRenderer {
 	return instance as TestGpuixRenderer;
 }
 
-export function mount_headless<Exports extends Record<string, any> = Record<string, any>>(
+export function mount_headless<Exports extends Record<string, unknown> = Record<string, unknown>>(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see AnyComponent
 	Component: Component<any, Exports, any>,
 	{ props = {}, width, height, rootStyle }: MountHeadlessOptions = {}
 ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,11 @@
  */
 
 import type { EventPayload, GpuixRenderer, TestGpuixRenderer, WindowOptions } from '@gpuix/native';
+import type { Component } from 'svelte';
+
+/** Any component at all: a `Component<{ a: 1 }>` is not a `Component<{}>`, so a mixed set has no other common type. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyComponent = Component<any, any, any>;
 
 export type NodeKind = 'fragment' | 'element' | 'text' | 'comment';
 
@@ -102,7 +107,7 @@ export type Native = GpuixRenderer | TestGpuixRenderer;
 export type WindowNative = Partial<Pick<GpuixRenderer, 'setWindowTitle' | 'activateWindow' | 'blur' | 'focusElement'>>;
 
 export interface RenderOptions extends WindowOptions {
-	props?: Record<string, any>;
+	props?: Record<string, unknown>;
 	rootStyle?: GpuiStyle;
 	onEvent?: (event: EventPayload) => void;
 	/** `on_window_key` handlers kept across remounts. */

--- a/test/HotImports.svelte
+++ b/test/HotImports.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Component } from 'svelte';
+	import type { AnyComponent } from 'gpuix-svelte';
 	import Static from './HotChild.svelte';
 	import './HotSideEffect.svelte';
 	import Shipped from 'gpuix-svelte/components/Scroller.svelte';
@@ -7,7 +7,7 @@
 	// import Commented from './HotComment.svelte';
 	const sample = "import Doc from './HotString.svelte'";
 
-	let loaded = $state<Component<any, any, any> | null>(null);
+	let loaded = $state<AnyComponent | null>(null);
 	const lazy = async () => (loaded = (await import('./HotLazy.svelte')).default);
 </script>
 

--- a/test/teardown.ts
+++ b/test/teardown.ts
@@ -6,7 +6,7 @@
 
 import { TestGpuixRenderer } from '@gpuix/native';
 import { flushSync } from 'svelte';
-import { renderer, set_native, create_root, commit, is_dirty, dispatch, type ShadowNode } from 'gpuix-svelte';
+import { renderer, set_native, create_root, is_dirty, dispatch, type ShadowNode } from 'gpuix-svelte';
 import { mount_headless, settle, all_text, check, finish } from 'gpuix-svelte/test';
 
 /** A root with no component in it, for trees built by hand. */

--- a/test/window-keys.ts
+++ b/test/window-keys.ts
@@ -8,7 +8,7 @@ import { on_window_key, set_window_title, activate_window, blur } from 'gpuix-sv
 import { mount_headless, find_test_id, focus, press, drain, settle, all_text, check, finish } from 'gpuix-svelte/test';
 
 const Keys = (await import('./WindowKeys.svelte')).default;
-let { native, unmount } = mount_headless(Keys);
+const { native, unmount } = mount_headless(Keys);
 
 const seen = () => all_text().find((t) => t.includes('|'));
 
@@ -43,7 +43,7 @@ off_up();
 let outer = 0;
 const off_outer = on_window_key('keydown', () => outer++);
 unmount();
-({ native, unmount } = mount_headless(Keys));
+mount_headless(Keys);
 press('c');
 check('a handler registered outside the tree survives a remount', outer, 1);
 check('and the remounted component hears it too', seen(), 'c|0');

--- a/types/svelte.d.ts
+++ b/types/svelte.d.ts
@@ -1,5 +1,4 @@
 declare module '*.svelte' {
-	import type { Component } from 'svelte';
-	const component: Component<any, any, any>;
+	const component: import('gpuix-svelte').AnyComponent;
 	export default component;
 }


### PR DESCRIPTION
Adds a flat ESLint config over src, tests and every example, with \`npm run lint\` run in the Linux CI job next to typecheck.

The config is only the recommended presets of \`@eslint/js\`, \`typescript-eslint\` and \`eslint-plugin-svelte\`, the TS parser for \`.svelte\` / \`.svelte.ts\`, Node + \`Bun\` globals, and ignores. No rules are overridden; everything the defaults flagged was fixed in code instead:

- \`Component<any, any, any>\` in eight places collapses into one exported \`AnyComponent\` alias with a single scoped disable — a \`Component<{ a: 1 }>\` is not a \`Component<{}>\`, so a mixed set of components has no other common type.
- The other \`any\`s became real types: \`unknown\` for props/exports, a \`ChatResponse\` shape in the LLM client, an \`ItemMeta\` interface for Substrate's JSON meta column, typed model handles in the ML worker.
- Ten unkeyed \`{#each}\` blocks got keys.
- Empty \`catch\` blocks: URL parses use \`URL.parse(x)?.…\`, the recording cleanup uses \`rmSync(..., { force: true })\`, the rest say why they swallow.
- The nbsp in a regex is written as \`\\u00a0\`; the useless assignments and an unused rest-sibling are gone.
- \`prefer-svelte-reactivity\`: the date formatter uses \`Intl.DateTimeFormat\`. \`RouteView\`'s route cache keeps a plain \`Map\` with a scoped disable, because it is written from inside a \`$derived\` — \`SvelteMap\` there fails the brain smoke test with \`state_unsafe_mutation\`.

Verified locally: \`npm run lint\`, \`npm run typecheck\`, \`npm test\` and \`npm run test:brain\`.