### PR TITLE
perf: one <markdown> row per block on Substrate's item view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,9 @@ npm run brain:compile      # dist/substrate + dist/Substrate.app via scripts/com
                            # embedded Bun (BUN_BE_BUN=1). Data goes to ~/Library/Application
                            # Support/Substrate. CODESIGN_IDENTITY / NOTARY_PROFILE as for compile.
 npm run brain:import-hn    # pours the Hacker News front page into the real brain (scrape smoke test)
+npm run brain:frames       # draw-time stats per route (idle and while scrolling) from GPUI's debug
+                           # frame overlay, against a copy of the data; `-- --keep /item/36` leaves
+                           # the window open with the overlay on. See "Measuring frame cost"
 
 npm test                   # test:reorder, test:smoke, test:autocommit, test:style,
                            # test:teardown, test:lifecycle, test:compile, test:css, test:module,
@@ -89,7 +92,7 @@ npm run test:brain         # Bun-only, chained into bun:test not test — exampl
                            # (WAV codec, page extractor, SSE parser, chunker, vector index, store +
                            # pipeline with a stub worker, real IPC client vs a fake worker incl. a crash)
                            # and test/smoke.ts (headless mount; capture, open, Esc, delete via real hit
-                           # testing). No models, no network.
+                           # testing; a long page paints only the rows in view). No models, no network.
 npm run test:coverage      # optional; needs SVELTE_SAMPLES_DIR (see below)
 npm run vendor             # re-vendor svelte: downloads pkg.svelte.dev's build of the PR
                            # head; see "Hard constraints". Not a runtime script, so no bun twin
@@ -150,6 +153,25 @@ GPUIX_SCREENSHOT=/tmp/x.png npm run demo:counter    # writes a PNG after every m
 
 Then open the PNG with the Read tool (Preview.app also reloads on write). Headless code calls
 `TestGpuixRenderer.captureScreenshot(path)` — real Metal pipeline, no window; see `test/smoke.ts`.
+
+### Measuring frame cost
+
+Scroll lag here is native per-frame layout, not JS, so measure before reasoning. `npm run
+brain:frames -- [--keep] [route ...]` (`examples/second-brain/scripts/frame-cost.ts`) boots
+Substrate against a `VACUUM INTO` copy of the data, visits each route (default: `/`, `/settings`
+and the item with the longest body), and prints a table of GPUI's own draw times — idle frames
+over 2 s, then p90/p99/max and fps while 90 wheel events scroll the content column; `--keep`
+leaves the window open with the overlay on for scrolling by hand. It is a thin script over the
+API both `GpuixRenderer` and `TestGpuixRenderer` expose: `setDebugFrameOverlay('full')`,
+`resetDebugFrameOverlayStats()`, `getDebugFrameOverlayStats()` (cur/p90/p99/max draw ms and a
+frame count) and `simulateScrollWheel(x, y, dx, dy)` — so a headless bench of one component is
+the same calls around `mount_headless` (from outside the repo it needs a `node_modules` of
+symlinks, `svelte` and `gpuix-svelte` → the repo, and a `{"type":"module"}` package.json, or tsx
+emits CJS). The window needs the Bash sandbox off, like every other renderer run. Baselines on
+2026-09-03 (native 0.7.0, 1180×780): the timeline ~4.6 ms a frame, settings ~7–9 ms, the item
+route ~5 ms since its Scroller went virtual (it was ~10 ms with a 12-character note and ~18 ms
+with a 226-block page before). Open: `/settings` blocks ~90 ms per simulated wheel event although
+its draw is ~9 ms.
 
 ### Standalone binary
 
@@ -406,7 +428,12 @@ the two stay in sync. Unknown events are dropped silently.
   `display: none` have the same problems in a class rule as inline (see the styling playground).
 - Only GPUI tags exist (`div`, `text`, `img`, `input`, `textarea`, `code`, `diff`, `markdown`,
   `virtual-list`, ...); anything else degrades to `div` with a one-time warning. `<img src>` is a
-  filesystem path or a `data:` URL, never http. `<svg source>` inherits **no** `color` natively,
+  filesystem path or a `data:` URL, never http. `<markdown>` is rebuilt and laid out in full on
+  every frame, on screen or not, and the cost follows its block count, not its bytes (a 226-block
+  page cost ~7 ms a frame headless, ~18 ms in Substrate's window), so a long document goes one
+  block per row under `<Scroller virtual>`, which brought it under 1 ms headless and the window
+  to ~5 ms — Substrate's `Item.svelte` with `lib/blocks.ts` (one row per top-level token of
+  `marked`'s lexer) is the example. `<svg source>` inherits **no** `color` natively,
   so the renderer copies the nearest ancestor's (from its class rules or inline style) onto any
   `<svg>` without one and re-copies it whenever that ancestor restyles; a parent's `:hover` colour
   does not reach it, since hover is native. Substrate's `Icon.svelte` still sets tones explicitly.
@@ -490,6 +517,42 @@ outside `src/plugin.ts` and `scripts/compile*.ts` (Bun is the compiler there). I
 `import type`, and components import the renderer's types (`ShadowNode` for `{@attach}`,
 `GpuixEvent` for handlers) from `'gpuix-svelte'`; `.svelte` files use `<script lang="ts">` — the
 compiler strips the types itself, and svelte-check is not part of the gate.
+
+## Working in this repo
+
+- Make file changes with the Edit/Write tools so every change shows as a diff; Bash is for
+  reading, running scripts and tests, and scratch files under `$TMPDIR`. Anything worth
+  remembering goes in this file, not in Claude Code's memory directory.
+- The headless renderer (Metal) crashes under Claude Code's Bash sandbox ("Swift Fatal error:
+  Array index out of range", hiservices XPC errors) — run `npm test`, `test:brain` and `consume`
+  with the sandbox disabled.
+- The machine has 16 GB of RAM and each `ml/worker.ts` loads ~1 GB of ONNX models with ORT's arena
+  on top: run one model-loading process at a time (the app, `brain:doctor`, the HN import — never
+  in parallel), check `ps -axo pid,rss,command | grep worker` after background runs and kill
+  orphans, and prefer `GPUIX_BRAIN_STUB=1` or `MlStub` for screenshots and tests. Keep the
+  safeguards: chunk length capped by characters, embedding batches of 8, `enableCpuMemArena:
+  false`, idle unload of Whisper/CLIP, the worker's orphan watchdog.
+- Sibling checkouts: `../gpuix` is the fork this repo was extracted from (2026-08-30) and lags at
+  native 0.4.0 — read upstream release tags instead (see "Regenerating README's styling
+  reference"); `../svelte` (khromov/svelte, branch `custom-condition`) is the local copy of the
+  custom-renderer PR stack, force-pushed about weekly.
+- npm does not verify lock integrity for `file:` tarballs and says "up to date" when a same-named
+  tarball changes bytes; if one is ever replaced under the same name, delete
+  `packages['node_modules/svelte']` from package-lock.json and `npm install`. `npm install` never
+  moves a locked version because a range widened — use `npm update <pkg>`.
+- `typescript` is pinned `^5.9`, not 7 (the Go port changes defaults such as `types: []`);
+  `@types/node` is pinned explicitly (bun-types' `*` would float); `types/node-ffi.d.ts` adds
+  `float32`/`float64`, which `node:ffi` accepts but `@types/node` omits. tsx, Bun and tsc all
+  silently map a stale `./x.js` specifier onto `x.ts`, so grep for `.js'` imports rather than
+  trusting the tests. The 17 `var(--…) is not defined` warnings on Substrate's first paint are
+  long-standing, not a regression.
+- `test:coverage` baseline: 32/47 samples mount, 13 refused by design, 2 runtime errors
+  (boundary-pending, raw-snippet).
+- `demo:glass-ffi` renders as an opaque dark slab over bright backdrops on every native version
+  tested: attaching the NSGlassEffectView itself turns the window opaque (the shim never opts into
+  behind-window sampling), not a renderer regression.
+- The npm name `gpuix-svelte` was reserved with a 0.0.1 placeholder on 2026-09-01, so the first
+  real release is 0.1.0.
 
 ## Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,10 @@ A window can't be inspected from a terminal, but a PNG can:
 ```bash
 GPUIX_SCREENSHOT=/tmp/x.png npm run demo:counter    # writes a PNG after every mount/remount
                                                     # (single demo — all four share the path)
+GPUIX_FPS=1 npm run brain                           # GPUI's draw-time overlay top right: CUR / 1% /
+                                                    # 10% / MAX ms and a frame count (=minimal shows
+                                                    # the last draw only). Draw time, not fps:
+                                                    # 8.3 ms is 120 Hz
 ```
 
 Then open the PNG with the Read tool (Preview.app also reloads on write). Headless code calls

--- a/examples/second-brain/README.md
+++ b/examples/second-brain/README.md
@@ -53,13 +53,16 @@ examples/second-brain/
   standalone.ts          the compiled entry: static imports, render() instead of render_hot()
   App.svelte             root layout, window-level shortcuts, the palette → set_css_vars, route table
   RouteView.svelte       resolves the route and lazy-loads the page component
-  routes/                Everything, Kind, Search, Item, Ask, Settings, NotFound
+  routes/                Everything, Kind, Search, Item, Ask, Settings, NotFound; Item renders a
+                         page one <markdown> block per virtual row (lib/blocks.ts), since a native
+                         markdown element lays out its whole document every frame
   components/            Sidebar, ItemCard, CaptureBox, Field, Modal (a <Portal>), …; scrolling
                          is the package's Scroller
   lib/                   the data layer (plain TS) and the UI state (.svelte.ts runes modules)
   ml/worker.ts           the child process that owns the models; ml/doctor.ts is the spike
   native/recorder-shim.m AVAudioRecorder over bun:ffi, compiled by clang on first use
-  scripts/import-hn.ts   the Hacker News importer
+  scripts/import-hn.ts   the Hacker News importer; frame-cost.ts prints GPUI draw times per route
+                         (npm run brain:frames), against a copy of the data
   test/                  brain.ts (data + native, no models) and smoke.ts (headless UI)
   icon.svg / icon.png    the logo; the .app's icon is cut from the PNG
   .data/                 gitignored: substrate.sqlite, files/, thumbs/, models/

--- a/examples/second-brain/README.md
+++ b/examples/second-brain/README.md
@@ -117,7 +117,7 @@ All optional, all `GPUIX_BRAIN_*`:
 | `RESOURCES=/path` | where a compiled app's worker and shim live (auto-detected inside a .app) |
 | `DEBUG=1` | verbose logging |
 
-`GPUIX_SCREENSHOT=/tmp/x.png` works as everywhere else. The API key lives in plain text in
+`GPUIX_SCREENSHOT=/tmp/x.png` and `GPUIX_FPS=1` (GPUI's draw-time overlay) work as everywhere else. The API key lives in plain text in
 `substrate.sqlite` when set through Settings; use `GPUIX_BRAIN_LLM_KEY` to keep it out.
 
 ## Things GPUI has no API for, and what stands in

--- a/examples/second-brain/lib/blocks.ts
+++ b/examples/second-brain/lib/blocks.ts
@@ -1,0 +1,16 @@
+/**
+ * Top-level markdown blocks as raw source, one per row of a virtual list: a native
+ * `<markdown>` lays out its whole document every frame, so a long page is rendered
+ * as many short ones instead.
+ */
+
+import { lexer } from 'marked';
+
+export function markdown_blocks(body: string): string[] {
+	const blocks: string[] = [];
+	for (const token of lexer(body ?? '', { gfm: true })) {
+		const raw = token.raw.trim();
+		if (raw) blocks.push(raw);
+	}
+	return blocks;
+}

--- a/examples/second-brain/routes/Item.svelte
+++ b/examples/second-brain/routes/Item.svelte
@@ -5,6 +5,7 @@
 	import Markdown from '../components/Markdown.svelte';
 	import Scroller from 'gpuix-svelte/components/Scroller.svelte';
 	import Spinner from '../components/Spinner.svelte';
+	import { markdown_blocks } from '../lib/blocks.ts';
 	import { playback, toggle_play } from '../lib/capture.svelte.ts';
 	import { write_text } from '../lib/clipboard.ts';
 	import { ago, data, format_duration, get_app, status_text } from '../lib/data.svelte.ts';
@@ -28,6 +29,9 @@
 		const first = lines.findIndex((line) => line.trim());
 		return first === -1 ? item.body : lines.slice(first + 1).join('\n').trim();
 	});
+	// One <markdown> per block: a native markdown element lays out its whole document every
+	// frame, and a virtual row is only built near the viewport.
+	const blocks = $derived(markdown_blocks(body_view));
 	const llm = $derived(data.capabilities?.llm?.ok ?? false);
 	const vision = $derived(llm && !!get_app().settings.get('llm.visionModel'));
 
@@ -144,8 +148,8 @@
 				></textarea>
 			</div>
 		{:else}
-			<Scroller pad="0 24px 32px 24px" gap={16}>
-				<div class="header">
+			<Scroller virtual estimate={44} pad="0 24px 32px 24px" testid="item-body">
+				<div class="row header">
 					<div class="meta">
 						<KindBadge kind={item.kind} />
 						<div>{ago(item.created_at)}</div>
@@ -167,23 +171,26 @@
 				</div>
 
 				{#if item.kind === 'image' && item.file_path}
-					<img src={item.meta.display_path ?? item.file_path} objectFit="contain" class="hero" />
+					<div class="row"><img src={item.meta.display_path ?? item.file_path} objectFit="contain" class="hero" /></div>
 				{/if}
 				{#if item.kind === 'link' && item.thumb_path}
-					<img src={item.thumb_path} objectFit="cover" class="og" />
+					<div class="row"><img src={item.thumb_path} objectFit="cover" class="og" /></div>
 				{/if}
 
 				{#if item.meta.summary}
-					<div class="summary">
-						<div class="summary-label">Summary</div>
-						<Markdown source={item.meta.summary} />
+					<div class="row">
+						<div class="summary">
+							<div class="summary-label">Summary</div>
+							<Markdown source={item.meta.summary} />
+						</div>
 					</div>
 				{/if}
 
-				{#if body_view}
-					<div class="body"><Markdown source={body_view} /></div>
-				{:else if !busy}
-					<div class="placeholder">
+				{#each blocks as block, i (i)}
+					<div class="block"><Markdown source={block} /></div>
+				{/each}
+				{#if !blocks.length && !busy}
+					<div class="row placeholder">
 						{#if item.kind === 'image'}
 							{vision
 								? 'No description yet — press Describe with LLM above.'
@@ -195,11 +202,11 @@
 				{/if}
 
 				{#if item.meta.describe_error}
-					<div class="placeholder">Description failed: {item.meta.describe_error}</div>
+					<div class="row placeholder">Description failed: {item.meta.describe_error}</div>
 				{/if}
 
 				{#if related.length}
-					<div class="related">
+					<div class="row related">
 						<div class="related-label">Related</div>
 						{#each related as hit (hit.item.id)}
 							<ItemCard item={hit.item} compact onopen={() => push(`/item/${hit.item.id}`)} />
@@ -220,7 +227,8 @@
 	.editor { display: flex; flex-direction: column; gap: 10px; flex-grow: 1; min-height: 0; padding: 16px 24px 24px 24px; }
 	.title-input { padding: 8px 10px; border-radius: 6px; border-width: 1px; font-size: 18px; line-height: 24px; font-weight: 600; background-color: var(--field); border-color: var(--borderStrong); color: var(--ink); }
 	.body-input { flex-grow: 1; min-height: 0; padding: 10px; border-radius: 6px; border-width: 1px; font-size: 14px; line-height: 22px; background-color: var(--field); border-color: var(--borderStrong); color: var(--ink); }
-	.header { display: flex; flex-direction: column; gap: 8px; padding-top: 16px; }
+	.row { display: flex; flex-direction: column; width: 100%; padding-bottom: 16px; }
+	.header { gap: 8px; padding-top: 16px; }
 	.meta { display: flex; flex-direction: row; align-items: center; gap: 10px; font-size: 12px; line-height: 16px; user-select: none; color: var(--inkFaint); }
 	.title { font-size: 26px; line-height: 34px; font-weight: 700; }
 	.url { font-size: 12px; line-height: 16px; cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--info); }
@@ -230,8 +238,8 @@
 	.og { width: 320px; height: 180px; border-radius: 8px; }
 	.summary { display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; border-radius: 10px; background-color: var(--accentSoft); }
 	.summary-label { font-size: 11px; line-height: 14px; font-weight: 600; user-select: none; color: var(--accentDeep); }
-	.body { max-width: 760px; }
+	.block { width: 100%; max-width: 760px; padding-bottom: 12px; }
 	.placeholder { font-size: 13px; line-height: 20px; color: var(--inkFaint); }
-	.related { display: flex; flex-direction: column; gap: 6px; padding-top: 8px; }
+	.related { gap: 6px; padding-top: 8px; }
 	.related-label { padding-bottom: 4px; font-size: 11px; line-height: 14px; font-weight: 600; user-select: none; color: var(--inkFaint); }
 </style>

--- a/examples/second-brain/scripts/frame-cost.ts
+++ b/examples/second-brain/scripts/frame-cost.ts
@@ -1,0 +1,87 @@
+/**
+ * Draw-time stats for Substrate's routes, from GPUI's own debug frame overlay: boots the
+ * app against a copy of the data (the real brain is never written), visits each route,
+ * and prints how long a frame takes at idle and while wheel events scroll the content
+ * column. Scroll lag here is native per-frame layout, so this is the number to read
+ * before looking at any JS.
+ *
+ *   npm run brain:frames -- [--keep] [route ...]     default: / /settings and the longest item
+ *
+ * `--keep` leaves the window open with the overlay on, for scrolling by hand.
+ */
+
+if (!process.versions.bun) {
+	console.error('[frames] needs Bun — `npm run brain:frames`');
+	process.exit(1);
+}
+
+process.env.GPUIX_BRAIN_OFFLINE = '1';
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+const keep = args.includes('--keep');
+const wanted = args.filter((a) => !a.startsWith('--'));
+
+const { Database } = await import('bun:sqlite');
+const { render, get_native } = await import('gpuix-svelte');
+const { create_app } = await import('../lib/app.ts');
+const { MlStub } = await import('../lib/ml-stub.ts');
+const { default_root } = await import('../lib/paths.ts');
+const { push } = await import('../lib/router.svelte.ts');
+const { WINDOW } = await import('../lib/window.ts');
+const App = (await import('../App.svelte')).default;
+
+const source = process.env.GPUIX_BRAIN_DIR || default_root();
+const data_dir = mkdtempSync(join(tmpdir(), 'substrate-frames-'));
+const copy = join(data_dir, 'substrate.sqlite');
+// VACUUM INTO reads through the WAL, so the copy is consistent even while the app is open.
+new Database(join(source, 'substrate.sqlite'), { readonly: true }).run('VACUUM INTO ?', [copy]);
+const longest = new Database(copy, { readonly: true }).query<{ id: number }, []>('SELECT id FROM items ORDER BY length(body) DESC LIMIT 1').get();
+const routes = wanted.length ? wanted : ['/', '/settings', ...(longest ? [`/item/${longest.id}`] : [])];
+console.log(`[frames] ${source} copied to ${data_dir}`);
+
+const app = await create_app({ data_dir, ml: new MlStub(), autoload: false });
+render(App, { ...WINDOW, props: { app } });
+const native = get_native()!;
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+await sleep(1500);
+const { width, height } = native.getWindowSize();
+native.setDebugFrameOverlay('full');
+
+const IDLE_MS = 2000;
+const WHEEL_EVENTS = 90;
+const rows: string[][] = [['route', 'idle frames', 'idle max', 'scroll p90', 'p99', 'max', 'fps']];
+for (const path of routes) {
+	push(path);
+	// A lazy route import, then the related-items query on an item page.
+	await sleep(1200);
+	native.resetDebugFrameOverlayStats();
+	await sleep(IDLE_MS);
+	const idle = native.getDebugFrameOverlayStats();
+
+	native.resetDebugFrameOverlayStats();
+	const started = performance.now();
+	for (let i = 0; i < WHEEL_EVENTS; i++) {
+		// The content column sits right of the sidebar.
+		native.simulateScrollWheel(width * 0.62, height * 0.6, 0, -30);
+		await sleep(16);
+	}
+	const elapsed = performance.now() - started;
+	const scroll = native.getDebugFrameOverlayStats();
+	const ms = (n?: number) => (n === undefined ? '-' : `${n.toFixed(1)} ms`);
+	rows.push([path, `${idle.frames}/${IDLE_MS / 1000}s`, ms(idle.maxMs), ms(scroll.p90Ms), ms(scroll.p99Ms), ms(scroll.maxMs), ((scroll.frames * 1000) / elapsed).toFixed(0)]);
+}
+
+const widths = (rows[0] ?? []).map((_, col) => Math.max(...rows.map((row) => row[col]?.length ?? 0)));
+for (const row of rows) console.log(row.map((cell, col) => cell.padEnd(widths[col] ?? 0)).join('  '));
+
+if (keep) {
+	console.log('[frames] window left open with the overlay on; close it to exit');
+} else {
+	app.close();
+	process.exit(0);
+}

--- a/examples/second-brain/test/brain.ts
+++ b/examples/second-brain/test/brain.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parse_appearance } from '../lib/appearance.ts';
 import { create_app } from '../lib/app.ts';
+import { markdown_blocks } from '../lib/blocks.ts';
 import { chunk_markdown } from '../lib/chunk.ts';
 import { normalize_base_url, parse_sse } from '../lib/llm.ts';
 import { MlClient } from '../lib/ml-client.ts';
@@ -193,6 +194,19 @@ import { check, finish } from 'gpuix-svelte/test';
 	check('fence never split', chunks.some((c) => c.text.includes('```js\nconst a = 1;\n\nconst b = 2;\n```')));
 	check('empty body → no chunks', chunk_markdown('').length, 0);
 	check('short body → one chunk', chunk_markdown('Just a line.').length, 1);
+
+	const page = 'Intro para.\n\n# Heading\nRight after.\n\n- one\n\n- two\n1. three\n\nAfter list.\n\n```js\nconst a = 1;\n\nconst b = 2;\n```\n\n| a | b |\n|---|---|\n| 1 | 2 |\n';
+	const blocks = markdown_blocks(page);
+	check('markdown_blocks splits on blank lines and headings', blocks.slice(0, 3).join('|'), 'Intro para.|# Heading|Right after.');
+	check('markdown_blocks keeps a loose list together', blocks[3], '- one\n\n- two');
+	check('markdown_blocks starts a block at an ordered list', blocks[4], '1. three');
+	check('markdown_blocks ends the list at prose', blocks[5], 'After list.');
+	check('markdown_blocks keeps a fence whole', blocks[6], '```js\nconst a = 1;\n\nconst b = 2;\n```');
+	check('markdown_blocks keeps table rows together', blocks[7], '| a | b |\n|---|---|\n| 1 | 2 |');
+	check('markdown_blocks count', blocks.length, 8);
+	check('markdown_blocks normalises CRLF', markdown_blocks('a\r\n\r\nb').join('|'), 'a|b');
+	check('markdown_blocks: an unterminated fence runs to the end', markdown_blocks('```\nx\n\ny').join('|'), '```\nx\n\ny');
+	check('markdown_blocks empty', markdown_blocks('').length, 0);
 
 	const index = new VectorIndex(4, 1);
 	const unit = (...v: number[]) => {

--- a/examples/second-brain/test/smoke.ts
+++ b/examples/second-brain/test/smoke.ts
@@ -21,6 +21,7 @@ import {
 	focus,
 	unfocus,
 	find,
+	find_all,
 	find_test_id,
 	click_text,
 	click_test_id,
@@ -34,7 +35,7 @@ import {
 import type { ClickOptions } from 'gpuix-svelte/test';
 import { create_app } from '../lib/app.ts';
 import { MlStub } from '../lib/ml-stub.ts';
-import { route } from '../lib/router.svelte.ts';
+import { push, route } from '../lib/router.svelte.ts';
 import { DARK, LIGHT } from '../lib/theme.ts';
 import { set_mode } from '../lib/theme.svelte.ts';
 import { ui } from '../lib/ui.svelte.ts';
@@ -44,7 +45,7 @@ await app.ingest.idle();
 
 const App = (await import('../App.svelte')).default;
 // 538 is the headless height cap; anything laid out below it cannot be hit.
-mount_headless(App, { props: { app }, width: 1100, height: 538 });
+const { native } = mount_headless(App, { props: { app }, width: 1100, height: 538 });
 
 /** A click, then the timers and dynamic imports a route change runs through. */
 async function tap(text: string, opts?: ClickOptions) {
@@ -93,6 +94,27 @@ await tap('Buy compost for the raised beds');
 await wait();
 await tap('Substrate');
 check('brand click goes home', route.path, '/');
+
+// A long body is one <markdown> row per block under a virtual Scroller: every block stays in
+// the tree, but only those near the viewport are built and painted.
+const paragraphs = Array.from({ length: 150 }, (_, i) => `Paragraph ${i} of the long page.`);
+const long_note = app.add_note({ title: 'Long page', body: paragraphs.join('\n\n') });
+await app.ingest.idle();
+push(`/item/${long_note.id}`);
+await wait();
+await wait();
+check('long page keeps a markdown row per block', find_all((n) => n.type === 'markdown').length, 150);
+check('and paints the first block', painted().includes('Paragraph 0 of the long page.'));
+check('but not the last', painted().includes('Paragraph 149 of the long page.'), false);
+const body_list = find_test_id('item-body')!;
+let last_block = -1;
+body_list.children!.forEach((row, i) => {
+	if (row.children?.some((c) => c.type === 'markdown')) last_block = i;
+});
+native.scrollToItem(body_list.id, last_block);
+await wait();
+check('scrolling to the end paints the last block', painted().includes('Paragraph 149 of the long page.'));
+await tap('Substrate');
 
 // Typing `k` into the search box offers `kind:`; picking a kind completes and searches.
 const search_input = find((n) => n.type === 'input');

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"eslint": "^10.9.1",
 				"eslint-plugin-svelte": "^3.23.0",
 				"globals": "^17.12.0",
+				"marked": "^18.0.11",
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.69.0"
 			},
@@ -1757,6 +1758,19 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/marked": {
+			"version": "18.0.11",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-18.0.11.tgz",
+			"integrity": "sha512-HnslJfsZkRPBDJRHvVtAaWlZHEpSu7u8LgQuJCELjRKuWR+hpq4A7sLq3p8HaI9ypVoXDXxV34CsQJEe1+J5Aw==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 		"brain:doctor": "bun examples/second-brain/ml/doctor.ts",
 		"brain:compile": "bun scripts/compile-brain.ts",
 		"brain:import-hn": "bun examples/second-brain/scripts/import-hn.ts",
+		"brain:frames": "node bin/gpuix-svelte.js --bun examples/second-brain/scripts/frame-cost.ts",
 		"test": "npm run typecheck && npm run test:reorder && npm run test:smoke && npm run test:autocommit && npm run test:style && npm run test:teardown && npm run test:lifecycle && npm run test:compile && npm run test:css && npm run test:module && npm run test:vars && npm run test:scroller && npm run test:hitbox && npm run test:window-keys && npm run test:portal",
 		"test:vars": "node bin/gpuix-svelte.js test/vars.ts",
 		"test:scroller": "node bin/gpuix-svelte.js test/scroller.ts",
@@ -125,6 +126,7 @@
 		"eslint": "^10.9.1",
 		"eslint-plugin-svelte": "^3.23.0",
 		"globals": "^17.12.0",
+		"marked": "^18.0.11",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.69.0"
 	},

--- a/src/render.ts
+++ b/src/render.ts
@@ -122,6 +122,10 @@ export function render(Component: AnyComponent, options: RenderOptions = {}): Re
 		});
 
 		slot.native.init(window_options);
+		// GPUI's draw-time readout, top right: `1` is the full one (CUR / 1% / 10% / MAX ms and a
+		// frame count), any other value is passed through (`minimal` is the last draw only).
+		const overlay = process.env.GPUIX_FPS;
+		if (overlay) slot.native.setDebugFrameOverlay(overlay === '1' ? 'full' : overlay);
 		console.log('[gpuix-svelte] created native window');
 	}
 


### PR DESCRIPTION
## Why

Opening a scraped link in Substrate (e.g. khromov.se) and scrolling was laggy. The item view rendered the whole page as one native `<markdown>` inside a plain, non-virtual Scroller, and gpuix rebuilds and lays out every block of that element on every frame, on screen or not. The cost follows the block count, not the byte count, so a list-heavy 9.6 KB page was worse than a 65 KB article. Nothing on the JS side scales with tree size per frame or per scroll event.

Measured in the real window with GPUI's debug frame overlay while wheel events scroll the note:

| | p90 per frame | worst frame |
|---|---|---|
| khromov.se before | 18 ms | 40 ms |
| khromov.se after | 4.9 ms | 6.2 ms |
| 65 KB article before → after | 12.8 ms → 4.4 ms | 19 ms → 6.8 ms |

## What

- `lib/blocks.ts`: `markdown_blocks(body)` returns the raw source of each top-level block, one row per token of `marked`'s lexer (a fence, a loose list or a table stays one block). `marked` is a zero-dependency dev dependency.
- `routes/Item.svelte`: `<Scroller virtual>` with one `<markdown>` per block; header, image, summary and related sections are rows too, spaced with the md theme's 12 px block gap so the rendering matches the single element.
- `scripts/frame-cost.ts` + `npm run brain:frames -- [--keep] [route ...]`: boots the app against a `VACUUM INTO` copy of the data, visits each route and prints idle and scrolling draw-time stats; `--keep` leaves the window open with the overlay on.
- Tests: ten `markdown_blocks` checks in `test/brain.ts`; `test/smoke.ts` opens a 150-paragraph note, checks every block is retained but only those in view are painted, then scrolls to the end.
- CLAUDE.md: a "Measuring frame cost" section, the `<markdown>` per-frame note, and a "Working in this repo" section with the notes that used to live in Claude's memory directory.

## Verified

`npm run typecheck`, `eslint .`, `npm run test:brain` and `npm test` all pass. The headless renderer needs Claude Code's Bash sandbox off, which is now documented.

## Left for later

- `/settings` blocks ~90 ms per simulated wheel event although its draw is ~9 ms.
- A native fix inside gpuix's `<markdown>` would help every consumer but needs an upstream release.
