### PR TITLE
feat: one Include feeds switch for the timeline, search, Ask and Related

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ npm run brain              # Substrate, the "second brain" example (examples/sec
                            # (scraped with HTMLRewriter), images, voice memos; hybrid search
                            # (nomic embeddings + FTS5 + CLIP, fused with RRF); RSS/Atom feeds
                            # polled on a per-feed cron (croner, in-process — the ML worker takes one
-                           # job at a time and does not exist without the ML deps), kept out of
-                           # search/Ask/Related behind search.includeFeeds; RAG chat over any
+                           # job at a time and does not exist without the ML deps), in or out of the
+                           # timeline/search/Ask/Related behind one feeds.include switch; RAG chat over any
                            # OpenAI-compatible endpoint; right-click menus on every surface
                            # (components/ContextMenu.svelte draws them, lib/menus.ts says what is
                            # in them); light/dark. Recording and playback work on macOS

--- a/examples/second-brain/App.svelte
+++ b/examples/second-brain/App.svelte
@@ -8,6 +8,7 @@
 	import TopBar from './components/TopBar.svelte';
 	import type { App } from './lib/app.ts';
 	import { bind_app } from './lib/data.svelte.ts';
+	import { bind_feeds } from './lib/feed-filter.svelte.ts';
 	import { back, push, route, type RouteEntry } from './lib/router.svelte.ts';
 	import { bind_theme, start_system_poll, tokens } from './lib/theme.svelte.ts';
 	import { focus, ui } from './lib/ui.svelte.ts';
@@ -19,6 +20,7 @@
 	untrack(() => {
 		bind_app(app);
 		bind_theme(app);
+		bind_feeds(app);
 		// Before the template below is styled; the $effect only carries later switches.
 		set_css_vars(tokens());
 	});

--- a/examples/second-brain/README.md
+++ b/examples/second-brain/README.md
@@ -43,11 +43,10 @@ to run.
   **full article** switch — off, only what the document
   itself carries is stored and no page is fetched per entry — and optional retention (keep the
   newest *n*, or *n* days; anything you have edited is never pruned). A missed poll is caught up
-  shortly after launch. Because a feed brings in far more than you do, feed items are **kept out of
-  search, Ask and Related** until *Include feeds* is ticked — the checkbox sits beside the kind
-  filters on the search page, and in Settings; a single query overrides it with `feeds:on`. The
-  timeline has its own *Include feeds* switch (on by default), so you can read a feed there while
-  keeping it out of search. Both choices are remembered. An entry whose URL you had already saved is adopted rather
+  shortly after launch. Because a feed brings in far more than you do, one *Include feeds* switch
+  decides whether its entries are part of the timeline, search, Ask and Related, or out of all of
+  them — it is on by default, the same switch appears on the timeline, beside the search page's kind
+  filters and in Settings, and it is remembered. A single query overrides it with `feeds:on`. An entry whose URL you had already saved is adopted rather
   than duplicated, and an entry you delete is never fetched again.
 - **Ask**: retrieval-augmented chat over the corpus with any OpenAI-compatible endpoint (Ollama,
   LM Studio, OpenAI, OpenRouter). Answers stream in as markdown; `[n]` citations become chips that

--- a/examples/second-brain/lib/feed-filter.svelte.ts
+++ b/examples/second-brain/lib/feed-filter.svelte.ts
@@ -1,0 +1,19 @@
+import type { Settings } from './settings.ts';
+
+const state = $state({ on: true });
+
+// A plain function rather than an exported $derived: a module cannot export one,
+// and a function that reads $state is tracked wherever it is called.
+export const include_feeds = () => state.on;
+
+let persist: ((on: boolean) => void) | null = null;
+
+export function bind_feeds(app: { settings: Pick<Settings, 'get' | 'set'> }) {
+	state.on = app.settings.get('feeds.include') !== false;
+	persist = (on) => app.settings.set('feeds.include', on);
+}
+
+export function set_include_feeds(on: boolean) {
+	state.on = on;
+	persist?.(on);
+}

--- a/examples/second-brain/lib/search.ts
+++ b/examples/second-brain/lib/search.ts
@@ -19,7 +19,7 @@ export interface SearchOptions {
 	limit?: number;
 	kinds?: Kind[] | null;
 	signals?: string[];
-	/** Overrides the `search.includeFeeds` setting for one call. */
+	/** Overrides the `feeds.include` setting for one call. */
 	feeds?: boolean;
 }
 
@@ -57,7 +57,7 @@ export function create_search({ store, vectors, images, ml, settings }: { store:
 	// first answer, not a missing signal; only a down worker degrades the search.
 	const usable = (model: 'embed' | 'clip') => ml.available && (ml.status?.worker === 'up' || ml.status?.[model]?.state === 'ready');
 	const threshold = (key: keyof MlLike['thresholds']) => ml.thresholds?.[key] ?? 0;
-	const include_feeds = () => settings.get('search.includeFeeds') === true;
+	const include_feeds = () => settings.get('feeds.include') !== false;
 	// The vector indexes know nothing about feeds, so the exclusion set comes from SQL.
 	const feed_filter = (with_feeds: boolean): ((group: number) => boolean) | null => {
 		if (with_feeds) return null;

--- a/examples/second-brain/lib/settings.ts
+++ b/examples/second-brain/lib/settings.ts
@@ -12,8 +12,7 @@ export interface SettingValues {
 	'stt.language': string;
 	'ml.autoload': boolean;
 	'index.embedModel': string | null;
-	'search.includeFeeds': boolean;
-	'timeline.includeFeeds': boolean;
+	'feeds.include': boolean;
 	'feeds.schedule': string;
 }
 
@@ -37,8 +36,7 @@ export const SETTINGS: Record<SettingKey, SettingSpec> = {
 	'stt.language': { default: '' },
 	'ml.autoload': { default: true },
 	'index.embedModel': { default: null, internal: true },
-	'search.includeFeeds': { default: false },
-	'timeline.includeFeeds': { default: true },
+	'feeds.include': { default: true },
 	'feeds.schedule': { default: DEFAULT_SCHEDULE }
 };
 

--- a/examples/second-brain/routes/Everything.svelte
+++ b/examples/second-brain/routes/Everything.svelte
@@ -6,28 +6,29 @@
 	import Scroller from 'gpuix-svelte/components/Scroller.svelte';
 	import Toggle from '../components/Toggle.svelte';
 	import type { GpuixEvent } from 'gpuix-svelte';
-	import { data, get_app } from '../lib/data.svelte.ts';
+	import { data } from '../lib/data.svelte.ts';
+	import { include_feeds, set_include_feeds } from '../lib/feed-filter.svelte.ts';
 	import { capture_actions } from '../lib/menus.ts';
 	import { push } from '../lib/router.svelte.ts';
 	import { focus, open_menu } from '../lib/ui.svelte.ts';
 
 	const PAGE = 200;
 	let page = $state(1);
-	let include_feeds = $state(get_app().settings.get('timeline.includeFeeds') !== false);
-	const items = $derived(include_feeds ? data.items : data.items.filter((i) => i.feed_id == null));
+	const items = $derived(include_feeds() ? data.items : data.items.filter((i) => i.feed_id == null));
 	const visible = $derived(items.slice(0, page * PAGE));
-
-	function toggle_feeds(on: boolean) {
-		include_feeds = on;
-		get_app().settings.set('timeline.includeFeeds', on);
-	}
 </script>
 
 <div class="route" onauxclick={(e: GpuixEvent) => open_menu(e, capture_actions())}>
 	<div class="capture"><CaptureBox /></div>
 	{#if data.counts.feeds > 0}
 		<div class="head">
-			<Toggle label="Include feeds" hint="{data.counts.feeds} of {data.counts.total} items came from a subscription." checked={include_feeds} onchange={toggle_feeds} testid="timeline-feeds" />
+			<Toggle
+				label="Include feeds"
+				hint="{data.counts.feeds} of {data.counts.total} items came from a subscription. The same switch covers search, Ask and Related."
+				checked={include_feeds()}
+				onchange={set_include_feeds}
+				testid="timeline-feeds"
+			/>
 		</div>
 	{/if}
 	<Scroller virtual estimate={100} pad="0 20px 20px 20px" testid="timeline">

--- a/examples/second-brain/routes/Search.svelte
+++ b/examples/second-brain/routes/Search.svelte
@@ -8,6 +8,7 @@
 	import Toggle from '../components/Toggle.svelte';
 	import type { GpuixEvent } from 'gpuix-svelte';
 	import { data, get_app } from '../lib/data.svelte.ts';
+	import { include_feeds, set_include_feeds } from '../lib/feed-filter.svelte.ts';
 	import { capture_actions } from '../lib/menus.ts';
 	import { parse_query } from '../lib/rank.ts';
 	import { push, replace } from '../lib/router.svelte.ts';
@@ -31,13 +32,11 @@
 	const q = $derived((query?.q ?? '').trim());
 	const parsed = $derived(parse_query(q));
 	let filter = $state('all');
-	let include_feeds = $state(get_app().settings.get('search.includeFeeds') === true);
 	// `feeds:on` in the query is the filter; the checkbox mirrors it, as the kinds do.
-	const feeds_on = $derived(parsed.feeds ?? include_feeds);
+	const feeds_on = $derived(parsed.feeds ?? include_feeds());
 
 	function toggle_feeds(on: boolean) {
-		include_feeds = on;
-		get_app().settings.set('search.includeFeeds', on);
+		set_include_feeds(on);
 		if (parsed.feeds != null) replace(`/search?q=${encodeURIComponent(parsed.text)}`);
 	}
 	// A kind: in the query is the filter; the segmented control mirrors it.
@@ -57,7 +56,7 @@
 	$effect(() => {
 		const text = q;
 		const kinds = filter === 'all' ? null : [filter];
-		const feeds = include_feeds;
+		const feeds = include_feeds();
 		// Re-run once the embedding model comes up, so keyword-only results upgrade.
 		void model_states;
 		void total;
@@ -92,7 +91,7 @@
 <div class="route" onauxclick={(e: GpuixEvent) => open_menu(e, capture_actions())}>
 	<div class="head">
 		<Segmented options={FILTERS} value={active} onchange={choose} small />
-		<Toggle label="Include feeds" checked={feeds_on} onchange={toggle_feeds} testid="include-feeds" />
+		<Toggle label="Include feeds" checked={feeds_on} onchange={toggle_feeds} testid="search-feeds" />
 		<div class="grow"></div>
 		{#if loading}<Spinner size={12} />{/if}
 		<div class="summary">{summary}</div>

--- a/examples/second-brain/routes/Settings.svelte
+++ b/examples/second-brain/routes/Settings.svelte
@@ -6,6 +6,7 @@
 	import Segmented from '../components/Segmented.svelte';
 	import Spinner from '../components/Spinner.svelte';
 	import { data, display_title, format_bytes, get_app, item_by_id, status_text } from '../lib/data.svelte.ts';
+	import { include_feeds, set_include_feeds } from '../lib/feed-filter.svelte.ts';
 	import { create_llm } from '../lib/llm.ts';
 	import { MODEL_IDS, type ModelName } from '../lib/ml-client.ts';
 	import type { SettingKey } from '../lib/settings.ts';
@@ -27,7 +28,6 @@
 		visionModel: settings.get('llm.visionModel') ?? ''
 	});
 	let language = $state(settings.get('stt.language') ?? '');
-	let include_feeds = $state(settings.get('search.includeFeeds') === true);
 	let schedule = $state(settings.get('feeds.schedule'));
 	let testing = $state(false);
 
@@ -183,13 +183,13 @@
 
 		<div class="section">
 			<div class="heading">Feeds</div>
-			<div class="hint">Subscriptions bring in far more than you do by hand, so what they bring is kept out of the way until you ask for it.</div>
+			<div class="hint">Subscriptions bring in far more than you do by hand. One switch decides whether what they bring is part of your brain or kept out of the way.</div>
 			<Toggle
-				label="Include feeds when you search"
-				hint="Also covers Ask and an item's Related list. A single query can override it with feeds:on."
-				checked={include_feeds}
-				onchange={(v) => { include_feeds = v; settings.set('search.includeFeeds', v); }}
-				testid="include-feeds"
+				label="Include feeds"
+				hint="Covers the timeline, search, Ask and an item's Related list — the same switch you see on those pages. A single query can override it with feeds:on."
+				checked={include_feeds()}
+				onchange={set_include_feeds}
+				testid="settings-feeds"
 			/>
 			<div class="hint">How often a new feed checks for entries — each feed can be given its own on the Feeds page.</div>
 			<Segmented options={SCHEDULES} value={schedule} onchange={(v) => { schedule = v; settings.set('feeds.schedule', v); }} />

--- a/examples/second-brain/test/brain.ts
+++ b/examples/second-brain/test/brain.ts
@@ -1027,12 +1027,19 @@ const feed_fetch: Fetcher = async (url) => {
   await app.ingest.idle();
   check("and creates no items", app.store.counts().total, 2);
 
-  // The feed's own words are searchable, but only when asked for.
+  // The feed's own words are searchable until the one switch takes them out.
   check(
-    "feed items are out of search",
-    (await app.search("nitrogen")).hits.length,
+    "feed items are searched by default",
+    (await app.search("nitrogen")).hits[0]?.item.id,
+    first.id,
+  );
+  check(
+    "the option hides them",
+    (await app.search("nitrogen", { feeds: false })).hits.length,
     0,
   );
+  app.settings.set("feeds.include", false);
+  check("the setting hides them", (await app.search("nitrogen")).hits.length, 0);
   check(
     "feeds:on reveals them",
     (await app.search("nitrogen feeds:on")).hits[0]?.item.id,
@@ -1048,18 +1055,6 @@ const feed_fetch: Fetcher = async (url) => {
     (await app.search("https://feed.test/post-1")).hits[0]?.item.id,
     first.id,
   );
-  check(
-    "rag retrieval skips feeds",
-    (await app.search("nitrogen", { feeds: false })).hits.length,
-    0,
-  );
-  app.settings.set("search.includeFeeds", true);
-  check(
-    "the setting reveals them",
-    (await app.search("nitrogen")).hits[0]?.item.id,
-    first.id,
-  );
-  app.settings.set("search.includeFeeds", false);
 
   const note = app.add_note({
     body: "Nitrogen notes: legumes fix it out of the air.",

--- a/examples/second-brain/test/smoke.ts
+++ b/examples/second-brain/test/smoke.ts
@@ -252,7 +252,7 @@ check('the timeline carries a feeds switch', painted().includes('Include feeds')
 check('and shows the feed entry', painted().includes('Mycelium and the wood wide web'));
 await tap('Include feeds');
 check('unticking it hides feed items', painted().includes('Mycelium and the wood wide web'), false);
-check('and the choice is stored', app.settings.get('timeline.includeFeeds'), false);
+check('and the choice is stored', app.settings.get('feeds.include'), false);
 
 push('/search?q=mycelium');
 await wait();
@@ -264,7 +264,12 @@ await tap('Include feeds');
 await wait(250);
 await wait();
 check('ticking it brings them back', painted().includes('Mycelium and the wood wide web'));
-check('and persists as a setting', app.settings.get('search.includeFeeds'), true);
+check('and persists as a setting', app.settings.get('feeds.include'), true);
+
+push('/');
+await wait();
+await wait();
+check('the timeline follows the same switch', painted().includes('Mycelium and the wood wide web'));
 
 await tap('Mycelium and the wood wide web');
 await wait();
@@ -274,9 +279,11 @@ check('and which feed it came from', painted().includes('Newsonaut'));
 push('/settings');
 await wait();
 await wait();
-check('settings carries the search switch', all_text().some((t) => t.includes('Include feeds when you search')));
+check('settings carries the same switch', all_text().some((t) => t.includes("Covers the timeline, search, Ask and an item's Related list")));
+// The tick is a filled box, so the palette's accent is what says the switch is on.
+check('and it carries what search just set', find_test_id('settings-feeds')?.children?.[0]?.style?.backgroundColor, DARK.accent);
 
 console.log('screenshot:', screenshot(join(tmpdir(), 'substrate-smoke.png')));
 
 app.close();
-finish('smoke', 65);
+finish('smoke', 67);


### PR DESCRIPTION
Substrate had two settings and three checkboxes that never agreed with each other:

| Surface | Key | Default |
|---|---|---|
| timeline (`routes/Everything.svelte`) | `timeline.includeFeeds` | on |
| search (`routes/Search.svelte`) | `search.includeFeeds` | off |
| Settings ("Include feeds when you search") | `search.includeFeeds` | off |

Each was a `$state` snapshot taken at mount, so flipping one never moved the others — Settings and the search page disagreed until the route was remounted, and the timeline was a different setting entirely.

## What changed

- **One key**: `feeds.include`, default **on**, replacing both. `lib/search.ts` reads it, so search, Ask and Related follow the same switch as the timeline.
- **`lib/feed-filter.svelte.ts`** (new) holds it as module `$state` on the `lib/theme.svelte.ts` pattern — `include_feeds()` / `set_include_feeds()`, bound once from `App.svelte`. All three toggles read the live value, so a toggle anywhere moves the rest and the search page re-runs its query.
- Settings' switch is relabelled, since it is no longer search-only, and the three `testid`s are now distinct (`timeline-feeds`, `search-feeds`, `settings-feeds`).
- Old `search.includeFeeds` / `timeline.includeFeeds` rows are left behind rather than migrated — an existing brain starts at the new default.

Unchanged: `feeds:on|off` in a query and the per-call `feeds` option still override the setting, Related on a feed item still gets feed neighbours, and the per-kind lists still never filtered feeds.

## Tests

`test/brain.ts`'s feed block now asserts the default *includes* feed items and that the setting, the query token and the option each still take them out or bring them back; `test/smoke.ts` gained the cross-view checks — ticking on `/search` shows the feed entry back on the timeline and the switch already ticked in Settings.

`npm run typecheck`, `npm run lint`, `npm run bun:test:brain` and `npm run check:svelte -- examples/second-brain` all pass.